### PR TITLE
Add Cursor issue intake workflow

### DIFF
--- a/.github/workflows/cursor-issue-intake.yml
+++ b/.github/workflows/cursor-issue-intake.yml
@@ -1,0 +1,278 @@
+name: Cursor issue intake
+
+on:
+  issues:
+    types:
+      - labeled
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: GitHub issue number to send to Cursor Agent
+        required: true
+        type: number
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: cursor-issue-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: false
+
+env:
+  CURSOR_READY_LABEL: cursor-ready
+
+jobs:
+  cursor-agent:
+    name: Run Cursor Agent for issue
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'cursor-ready'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Resolve issue context
+        id: issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            gh issue view "${{ inputs.issue_number }}" \
+              --json number,title,body,url,labels \
+              --jq '{number,title,body,url,labels:[.labels[].name]}' > /tmp/cursor_issue.json
+          else
+            jq '{number:.issue.number,title:.issue.title,body:.issue.body,url:.issue.html_url,labels:[.issue.labels[].name]}' \
+              "$GITHUB_EVENT_PATH" > /tmp/cursor_issue.json
+          fi
+
+          issue_number="$(jq -r '.number' /tmp/cursor_issue.json)"
+          issue_url="$(jq -r '.url' /tmp/cursor_issue.json)"
+
+          echo "number=$issue_number" >> "$GITHUB_OUTPUT"
+          echo "url=$issue_url" >> "$GITHUB_OUTPUT"
+
+      - name: Comment start status
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          {
+            echo "Cursor Agent взял issue в работу."
+            echo
+            echo "Run: $RUN_URL"
+          } > /tmp/cursor_start_comment.md
+
+          gh issue comment "$ISSUE_NUMBER" --body-file /tmp/cursor_start_comment.md
+
+      - name: Build Cursor prompt
+        run: |
+          set -euo pipefail
+
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          issue = json.loads(Path("/tmp/cursor_issue.json").read_text())
+          labels = ", ".join(issue.get("labels") or [])
+          body = issue.get("body") or "_Описание issue пустое._"
+
+          prompt = f"""Ты работаешь в GitHub Actions над issue из репозитория.
+
+          Issue #{issue["number"]}: {issue["title"]}
+          URL: {issue["url"]}
+          Labels: {labels or "_нет_"}
+
+          Описание issue:
+          {body}
+
+          Задача:
+          - Изучи репозиторий и выполни запрос из issue.
+          - Следуй существующему стилю проекта.
+          - Не создавай git branch, commit, push, pull request и не комментируй GitHub: это делает workflow.
+          - Если для выполнения нужны уточнения, не вноси догадочные изменения. В финальном выводе отдельной строкой напиши: NEEDS_INPUT: <конкретный вопрос>.
+          - Если изменения внесены, кратко перечисли что сделано и какие проверки запущены.
+          """
+
+          Path("/tmp/cursor_prompt.md").write_text(prompt)
+          PY
+
+      - name: Install Cursor CLI
+        run: |
+          set -euo pipefail
+
+          curl https://cursor.com/install -fsS | bash
+          echo "$HOME/.cursor/bin" >> "$GITHUB_PATH"
+
+      - name: Run Cursor Agent
+        id: cursor
+        env:
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+        run: |
+          set +e
+
+          agent -p --trust --force --output-format text "$(cat /tmp/cursor_prompt.md)" 2>&1 | tee /tmp/cursor_agent_output.txt
+          exit_code="${PIPESTATUS[0]}"
+
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Detect agent result
+        id: result
+        run: |
+          set -euo pipefail
+
+          if grep -q '^NEEDS_INPUT:' /tmp/cursor_agent_output.txt; then
+            echo "needs_input=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "needs_input=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Comment failure
+        if: steps.cursor.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          printf '%s\n' "$RUN_URL" > /tmp/run_url
+
+          python3 - <<'PY' > /tmp/cursor_failure_comment.md
+          from pathlib import Path
+
+          output = Path("/tmp/cursor_agent_output.txt").read_text(errors="replace")[-4000:]
+          print("Cursor Agent завершился с ошибкой.")
+          print()
+          print(f"Run: {Path('/tmp/run_url').read_text().strip()}")
+          print()
+          print("Последние строки вывода:")
+          print()
+          print("```")
+          print(output)
+          print("```")
+          PY
+
+          gh issue comment "$ISSUE_NUMBER" --body-file /tmp/cursor_failure_comment.md
+          exit 1
+
+      - name: Comment needs input
+        if: steps.cursor.outputs.exit_code == '0' && (steps.result.outputs.needs_input == 'true' || steps.result.outputs.has_changes == 'false')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          printf '%s\n' "$RUN_URL" > /tmp/run_url
+
+          python3 - <<'PY' > /tmp/cursor_needs_input_comment.md
+          from pathlib import Path
+
+          output = Path("/tmp/cursor_agent_output.txt").read_text(errors="replace")[-4000:]
+          print("Cursor Agent не внёс изменений и ждёт уточнений.")
+          print()
+          print(f"Run: {Path('/tmp/run_url').read_text().strip()}")
+          print()
+          print("Вывод агента:")
+          print()
+          print("```")
+          print(output)
+          print("```")
+          PY
+
+          gh issue comment "$ISSUE_NUMBER" --body-file /tmp/cursor_needs_input_comment.md
+
+      - name: Commit and push changes
+        id: push
+        if: steps.cursor.outputs.exit_code == '0' && steps.result.outputs.needs_input == 'false' && steps.result.outputs.has_changes == 'true'
+        env:
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          branch_name="cursor/issue-${ISSUE_NUMBER}-${RUN_ID}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch_name"
+          git add -A
+          git commit -m "Implement issue #${ISSUE_NUMBER} with Cursor Agent"
+          git push -u origin "$branch_name"
+
+          echo "branch_name=$branch_name" >> "$GITHUB_OUTPUT"
+
+      - name: Create pull request and comment issue
+        if: steps.push.outputs.branch_name != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+          BRANCH_NAME: ${{ steps.push.outputs.branch_name }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          title="$(jq -r '.title' /tmp/cursor_issue.json)"
+
+          python3 - <<'PY' > /tmp/cursor_pr_body.md
+          from pathlib import Path
+          import json
+
+          issue = json.loads(Path("/tmp/cursor_issue.json").read_text())
+          output = Path("/tmp/cursor_agent_output.txt").read_text(errors="replace")[-4000:]
+
+          print("## Что сделано")
+          print()
+          print(f"Автоматическая работа Cursor Agent по issue #{issue['number']}.")
+          print()
+          print("## Тип изменений")
+          print()
+          print("- [ ] Исправление ошибки")
+          print("- [x] Новая возможность / документация")
+          print("- [ ] Рефакторинг (без смены поведения)")
+          print("- [ ] Прочее:")
+          print()
+          print("## Чеклист")
+          print()
+          print("- [x] Описание соответствует фактическим изменениям")
+          print("- [ ] При необходимости обновлены `README` / `docs` (отметьте N/A если не нужно)")
+          print()
+          print("## Примечания")
+          print()
+          print(f"Closes #{issue['number']}")
+          print()
+          print("Вывод агента:")
+          print()
+          print("```")
+          print(output)
+          print("```")
+          PY
+
+          pr_url="$(gh pr create \
+            --title "Issue #${ISSUE_NUMBER}: ${title}" \
+            --body-file /tmp/cursor_pr_body.md \
+            --base main \
+            --head "$BRANCH_NAME")"
+
+          {
+            echo "Cursor Agent подготовил PR: $pr_url"
+            echo
+            echo "Run: $RUN_URL"
+          } > /tmp/cursor_done_comment.md
+
+          gh issue comment "$ISSUE_NUMBER" --body-file /tmp/cursor_done_comment.md


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Что сделано

Кратко: добавлен GitHub Actions workflow `.github/workflows/cursor-issue-intake.yml`, который запускает Cursor Agent по label `cursor-ready` или вручную через `workflow_dispatch`, комментирует issue о статусе, пушит ветку с изменениями агента и создаёт PR.

## Тип изменений

- [ ] Исправление ошибки
- [x] Новая возможность / документация
- [ ] Рефакторинг (без смены поведения)
- [ ] Прочее:

## Чеклист

- [x] Описание соответствует фактическим изменениям
- [x] При необходимости обновлены `README` / `docs` (N/A: добавлен только workflow)

## Примечания

Проверено локально: YAML парсится через PyYAML, `run`-блоки проходят `bash -n`, генератор prompt выполняется на тестовом issue JSON. После merge нужно убедиться, что в GitHub Actions включено `Read and write permissions` для `GITHUB_TOKEN` и разрешено создание PR через Actions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10a682ec-930f-4a4b-952e-be156770d87a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10a682ec-930f-4a4b-952e-be156770d87a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

