### PR TITLE
Исправить баг переключения языка на страницах документов

### DIFF
--- a/document.html
+++ b/document.html
@@ -696,6 +696,9 @@
             const sourcePrefix = lang === 'ru' ? 'Источник' : 'Source';
             document.getElementById("doc-source").textContent = `${sourcePrefix}: ${activeDoc.path}`;
             
+            const contentElement = document.getElementById("markdown-content");
+            const tocElement = document.getElementById("toc-links");
+            
             fetch(activeDoc.path)
               .then((response) => {
                 if (!response.ok) {
@@ -708,19 +711,19 @@
               })
               .then((markdown) => {
                 const { html, headings } = renderMarkdown(markdown);
-                content.innerHTML = html;
-                toc.innerHTML = renderToc(headings, lang);
+                contentElement.innerHTML = html;
+                tocElement.innerHTML = renderToc(headings, lang);
               })
               .catch((error) => {
                 const errorTitle = lang === 'ru' ? 'Документ не загрузился.' : 'Document failed to load.';
                 const tocError = lang === 'ru' ? 'Оглавление недоступно.' : 'Contents unavailable.';
-                content.innerHTML = `
+                contentElement.innerHTML = `
                   <div class="empty-state">
                     <p><strong>${errorTitle}</strong></p>
                     <p>${escapeHtml(error.message)}</p>
                   </div>
                 `;
-                toc.innerHTML = `<span class="muted">${tocError}</span>`;
+                tocElement.innerHTML = `<span class="muted">${tocError}</span>`;
               });
           }
         });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Что сделано

Исправлен баг, из-за которого не работало переключение языка на странице `document.html` (манифест, README и архитектура системы).

**Проблема:** При клике на кнопки RU/EN документ оставался на английском языке, так как в обработчике события переключения языка использовались необъявленные переменные `content` и `toc`, которые были определены только позже в коде.

**Решение:** Добавлены локальные ссылки на DOM-элементы внутри обработчика события:
- `const contentElement = document.getElementById("markdown-content")`
- `const tocElement = document.getElementById("toc-links")`

Теперь при переключении языка:
1. Обновляется интерфейс (заголовки, описания, навигация)
2. Загружается правильная версия документа (`.md` для RU, `.en.md` для EN)
3. Обновляется содержимое и оглавление

## Тип изменений

- [x] Исправление ошибки
- [ ] Новая возможность / документация
- [ ] Рефакторинг (без смены поведения)
- [ ] Прочее:

## Чеклист

- [x] Описание соответствует фактическим изменениям
- [x] При необходимости обновлены `README` / `docs` (N/A - изменения только в HTML)

## Примечания

Протестировано вручную на всех трёх типах документов:
- ✅ Манифест (`document.html?doc=manifest`)
- ✅ README (`document.html?doc=readme`)
- ✅ Архитектура (`document.html?doc=system`)

Переключение между русским и английским языками работает корректно во всех случаях.

![Манифест на русском](https://cursor.com/artifacts/c/art-91245e6a-1968-4920-8228-810d83ffe74b)
![Манифест на английском](https://cursor.com/artifacts/c/art-8d6e366e-af08-4a8e-bdea-2facd6b24170)
![README на русском](https://cursor.com/artifacts/c/art-17d71bc7-f417-4831-96ce-93d0e36d90bd)
![Архитектура на русском](https://cursor.com/artifacts/c/art-5fadcd3f-0d62-492f-aa4f-8cdba1f57c91)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7290a45-0695-4226-8f4d-1e102b6d0ff2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7290a45-0695-4226-8f4d-1e102b6d0ff2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

