### PR TITLE
Update AGENTS.md to reflect current codebase state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,14 +2,16 @@
 
 ## Overview
 
-Atman — документационный проект, описывающий архитектуру психологического слоя для AI-агента. Репозиторий находится на стадии **прототипирования** и содержит только документацию (markdown-файлы, изображения, шаблоны).
-
-Исполняемого кода, зависимостей, тестов и сборочных конфигураций пока нет.
+Atman — проект психологического слоя для AI-агента, находящийся на стадии **прототипирования**. Содержит документацию (markdown-файлы, изображения, шаблоны) и первый реализованный компонент — **Factual Memory Adapter** (Python-пакет `atman`).
 
 ## Cursor Cloud specific instructions
 
 ### Структура репозитория
 
+- `src/atman/` — Python-пакет (модели, порты, адаптеры, CLI)
+- `tests/` — юнит-тесты (pytest)
+- `src/demo.py` — демо-скрипт
+- `pyproject.toml` — конфигурация проекта и зависимости
 - `MANIFEST.md` — философский манифест проекта
 - `docs/architecture/SYSTEM.md` — подробная архитектура системы (7 компонентов, режимы работы, протоколы)
 - `docs/research/` — исследования (mem0, интеграции)
@@ -19,17 +21,16 @@ Atman — документационный проект, описывающий 
 
 ### Lint / Test / Build / Run
 
-На текущем этапе в репозитории нет:
-- исполняемого кода (Python, JS, и т.д.)
-- файлов зависимостей (`pyproject.toml`, `package.json`, `requirements.txt`)
-- тестов или линтеров
-- CI/CD workflows
-
-Работа с репозиторием ограничена редактированием markdown-документации.
+- **Python ≥ 3.12** required (see `pyproject.toml`)
+- **Install**: `pip install -e ".[dev]"`
+- **Tests**: `pytest tests/ -v` (49 tests, all passing)
+- **CLI (REPL)**: `python3 -m atman.cli`
+- **Demo**: `python3 src/demo.py`
+- No external services (databases, Docker, etc.) are required — storage is in-memory or file-based (JSONL)
+- No linter is configured yet; no CI/CD workflows
 
 ### Планируемый стек (из архитектурных документов)
 
-Когда код появится, проект будет использовать:
 - Python ≥ 3.12, менеджер пакетов `uv`, build-система Hatchling
 - PydanticAI + Anthropic (Claude), mem0, APScheduler
 - Детали см. в `docs/architecture/SYSTEM.md`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Что сделано

Обновлён `AGENTS.md`, чтобы отразить текущее состояние репозитория после реализации Factual Memory Adapter. Старая версия утверждала, что исполняемого кода, зависимостей и тестов нет — это больше не соответствует действительности.

Ключевые изменения:
- Добавлена информация о структуре Python-пакета (`src/atman/`, `tests/`, `src/demo.py`, `pyproject.toml`)
- Раздел «Lint / Test / Build / Run» обновлён с актуальными командами: `pip install -e ".[dev]"`, `pytest tests/ -v`, `python3 -m atman.cli`, `python3 src/demo.py`
- Указано, что внешние сервисы не требуются

## Тип изменений

- [ ] Исправление ошибки
- [x] Новая возможность / документация
- [ ] Рефакторинг (без смены поведения)
- [ ] Прочее:

## Чеклист

- [x] Описание соответствует фактическим изменениям
- [x] При необходимости обновлены `README` / `docs`

## Примечания

Все 49 тестов проходят. Демо-скрипт и CLI работают корректно.

[pytest_output.log](https://cursor.com/artifacts/c/art-777c4132-7358-4a00-9f6a-60bcef8ac26f)
[demo_output.log](https://cursor.com/artifacts/c/art-b64fdb7b-c6cd-45f5-8eb9-5c9aab6efae8)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a957fee8-e808-40a3-ac3f-e0f5386eb225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a957fee8-e808-40a3-ac3f-e0f5386eb225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

