### PR TITLE
Add merge conflict detection to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-merge-conflict
+        args: [--assume-in-merge]
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.12
     hooks:


### PR DESCRIPTION
## Что сделано

Добавлен хук `check-merge-conflict` из `pre-commit-hooks` в конфигурацию `.pre-commit-config.yaml` для автоматического обнаружения маркеров конфликтов слияния в коммитах.

## Как воспроизвести (демонстрация)

**N/A** — изменение касается только конфигурации инструмента разработки, не влияет на поведение приложения для пользователя.

## Тип изменений

- [ ] Исправление ошибки
- [ ] Новая возможность / документация
- [x] Рефакторинг (без смены поведения)
- [ ] Прочее:

## Карта системы

**N/A** — изменение не затрагивает архитектуру, модули, порты или адаптеры системы.

## Тесты-страховки агентной разработки

**N/A** — изменение касается только конфигурации pre-commit, не затрагивает исходный код или тесты.

## Чеклист

- [x] Описание соответствует фактическим изменениям
- [x] При необходимости обновлены `README` / `docs` / демо-сценарий — **N/A**, не требуется
- [x] При необходимости обновлены `docs/architecture/SYSTEM_MAP.md` — **N/A**, не требуется
- [x] `ruff check src/ tests/` — **N/A**, не затрагивает код
- [x] `ruff format --check src/ tests/` — **N/A**, не затрагивает код
- [x] `pyright src/ tests/` — **N/A**, не затрагивает код
- [x] `bandit -c pyproject.toml -r src/atman/` — **N/A**, не затрагивает код
- [x] `pytest tests/ -v --cov=atman --cov-fail-under=90` — **N/A**, не затрагивает код

## Примечания

Хук будет автоматически запускаться при коммитах и предотвращать случайное добавление маркеров конфликтов слияния (`<<<<<<<`, `=======`, `>>>>>>>`) в репозиторий. Флаг `--assume-in-merge` позволяет хуку корректно работать в контексте разрешения конфликтов.

https://claude.ai/code/session_01UHoNQq44twa3jKuXjsWXXa