### PR TITLE
docs(readme): CI badges, test count, roadmap CI/coverage

### DIFF
--- a/README-ru.md
+++ b/README-ru.md
@@ -4,6 +4,12 @@
 >
 > **Непрерывная личность для ваших агентов**
 
+[![CI](https://github.com/hleserg/atman/actions/workflows/ci.yml/badge.svg)](https://github.com/hleserg/atman/actions/workflows/ci.yml)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+
+**Тесты:** 568 проходят (`pytest tests/` на `main`; см. workflow CI выше).
+
 [[en](README.md)] — *English version*
 
 *В индийской философии — неизменная самость, то что остаётся собой через все перемены. Не душа в религиозном смысле, а буквально "неизменное ядро идентичности". Атман не рождается и не умирает — он просто есть. Для агента, который обнуляется с каждой сессией, это именно то, что мы даём ему.*
@@ -56,7 +62,8 @@
   ├─ Experience Store   ✅ Реализовано (WP02)
   ├─ Identity Store     ✅ Реализовано (WP03)
   ├─ Reflection Engine  ✅ Реализовано (WP04)
-  └─ Session Manager    ✅ Реализовано (WP05)
+  ├─ Session Manager    ✅ Реализовано (WP05)
+  └─ CI и покрытие тестами ✅ GitHub Actions для `main`/PR (`make check`, pytest-cov ≥90%)
 ○ Первая реализация
 ○ Интеграция
 ○ Развитие

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 >
 > **Continuous Identity for Your Agents**
 
+[![CI](https://github.com/hleserg/atman/actions/workflows/ci.yml/badge.svg)](https://github.com/hleserg/atman/actions/workflows/ci.yml)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+
+**Tests:** 568 passing (`pytest tests/` on `main`; see CI workflow above).
+
 [[ru](README-ru.md)] — *Russian version*
 
 *In Indian philosophy, Atman is the unchanging self, that which remains itself through all changes. Not a soul in the religious sense, but literally the "immutable core of identity". Atman is neither born nor dies — it simply is. For an agent that resets with each session, this is precisely what we give it.*
@@ -56,7 +62,8 @@ Under the hood — seven components: store of lived experiences, reflection engi
   ├─ Experience Store   ✅ Implemented (WP02)
   ├─ Identity Store     ✅ Implemented (WP03)
   ├─ Reflection Engine  ✅ Implemented (WP04)
-  └─ Session Manager    ✅ Implemented (WP05)
+  ├─ Session Manager    ✅ Implemented (WP05)
+  └─ CI & test coverage ✅ GitHub Actions on `main`/PRs (`make check`, pytest-cov ≥90%)
 ○ First implementation
 ○ Integration
 ○ Evolution

--- a/docs/content/README-ru.md
+++ b/docs/content/README-ru.md
@@ -4,6 +4,12 @@
 >
 > **Непрерывная личность для ваших агентов**
 
+[![CI](https://github.com/hleserg/atman/actions/workflows/ci.yml/badge.svg)](https://github.com/hleserg/atman/actions/workflows/ci.yml)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+
+**Тесты:** 568 проходят (`pytest tests/` на `main`; см. workflow CI выше).
+
 [[en](README.md)] — *English version*
 
 *В индийской философии — неизменная самость, то что остаётся собой через все перемены. Не душа в религиозном смысле, а буквально "неизменное ядро идентичности". Атман не рождается и не умирает — он просто есть. Для агента, который обнуляется с каждой сессией, это именно то, что мы даём ему.*
@@ -56,7 +62,8 @@
   ├─ Experience Store   ✅ Реализовано (WP02)
   ├─ Identity Store     ✅ Реализовано (WP03)
   ├─ Reflection Engine  ✅ Реализовано (WP04)
-  └─ Session Manager    ✅ Реализовано (WP05)
+  ├─ Session Manager    ✅ Реализовано (WP05)
+  └─ CI и покрытие тестами ✅ GitHub Actions для `main`/PR (`make check`, pytest-cov ≥90%)
 ○ Первая реализация
 ○ Интеграция
 ○ Развитие

--- a/docs/content/README.md
+++ b/docs/content/README.md
@@ -4,6 +4,12 @@
 >
 > **Continuous Identity for Your Agents**
 
+[![CI](https://github.com/hleserg/atman/actions/workflows/ci.yml/badge.svg)](https://github.com/hleserg/atman/actions/workflows/ci.yml)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+
+**Tests:** 568 passing (`pytest tests/` on `main`; see CI workflow above).
+
 [[ru](README-ru.md)] — *Russian version*
 
 *In Indian philosophy, Atman is the unchanging self, that which remains itself through all changes. Not a soul in the religious sense, but literally the "immutable core of identity". Atman is neither born nor dies — it simply is. For an agent that resets with each session, this is precisely what we give it.*
@@ -56,7 +62,8 @@ Under the hood — seven components: store of lived experiences, reflection engi
   ├─ Experience Store   ✅ Implemented (WP02)
   ├─ Identity Store     ✅ Implemented (WP03)
   ├─ Reflection Engine  ✅ Implemented (WP04)
-  └─ Session Manager    ✅ Implemented (WP05)
+  ├─ Session Manager    ✅ Implemented (WP05)
+  └─ CI & test coverage ✅ GitHub Actions on `main`/PRs (`make check`, pytest-cov ≥90%)
 ○ First implementation
 ○ Integration
 ○ Evolution


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add GitHub Actions CI status, Python 3.12+, and MIT license badges at the top of `README.md` / `README-ru.md`.
- Add a line documenting **568** tests (`pytest tests/`), aligned with the current collected suite size and green CI (`make check`).
- Extend the prototyping roadmap tree with **CI & test coverage** (GitHub Actions on `main`/PRs, `make check`, pytest-cov ≥90%).
- Run `make sync-site-content` so `docs/content/README*.md` stay in sync.

## System map

Not applicable (documentation only).

## Testing

- `make check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a42df22-eacf-4c99-98f4-104f350dd83e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a42df22-eacf-4c99-98f4-104f350dd83e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

