### PR TITLE
playbook: PLAYBOOK markers infrastructure + initial audit (stages 1, 3, 4, 5)

### DIFF
--- a/.cursor/rules/playbook-markers.mdc
+++ b/.cursor/rules/playbook-markers.mdc
@@ -1,0 +1,22 @@
+---
+description: Reminds agents to add PLAYBOOK markers for generalizable patterns
+globs:
+  - "src/**/*.py"
+  - "docs/**/*.md"
+alwaysApply: false
+---
+
+# PLAYBOOK markers
+
+When implementing new code or writing new docs, check if you're introducing
+a generalizable engineering pattern (one that's applicable beyond this
+specific project).
+
+If yes — add a PLAYBOOK marker. See `AGENTS.md` section "PLAYBOOK markers"
+for criteria and format.
+
+Apply the substitution test: rewrite the pattern description without
+project-specific terms. If it still makes sense — it's generalizable.
+
+When in doubt, add the marker with `status: draft`. Better to over-mark
+than under-mark.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,13 @@
+## PLAYBOOK markers
+
+- [ ] I introduced new generalizable patterns and added PLAYBOOK markers
+- [ ] I introduced no generalizable patterns (pure refactoring / project-specific changes)
+- [ ] I'm uncertain — flagged in the PR description for author review
+
+*See `AGENTS.md` § "PLAYBOOK markers" and `docs/development/PLAYBOOK_MARKERS.md` for criteria.*
+
+---
+
 ## Что сделано
 
 Кратко: смысл изменений для ревьюера.

--- a/.github/workflows/playbook-sync.yml
+++ b/.github/workflows/playbook-sync.yml
@@ -1,0 +1,67 @@
+name: playbook-sync
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'docs/**'
+      - 'scripts/extract_playbook.py'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout atman
+        uses: actions/checkout@v4
+        with:
+          path: atman
+          fetch-depth: 0
+
+      - name: Checkout playbook
+        uses: actions/checkout@v4
+        with:
+          repository: hleserg/agent-playbook
+          path: agent-playbook
+          token: ${{ secrets.PLAYBOOK_SYNC_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install deps
+        run: |
+          cd atman
+          pip install pyyaml
+
+      - name: Validate markers
+        run: |
+          cd atman
+          python scripts/extract_playbook.py --check
+
+      - name: Extract markers
+        run: |
+          cd atman
+          python scripts/extract_playbook.py \
+            --target ../agent-playbook/raw/extracted-from-atman.md
+
+      - name: Check for changes
+        id: check
+        run: |
+          cd agent-playbook
+          if git diff --quiet; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          cd agent-playbook
+          git config user.name "playbook-sync-bot"
+          git config user.email "playbook-sync@hleserg"
+          git add raw/extracted-from-atman.md
+          git commit -m "auto-sync from atman: $(cd ../atman && git rev-parse --short HEAD)"
+          git push

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,12 @@ repos:
         args: [-c, pyproject.toml]
         files: ^src/atman/
         additional_dependencies: ["bandit[toml]"]
+
+  - repo: local
+    hooks:
+      - id: playbook-check
+        name: Validate PLAYBOOK markers
+        entry: python scripts/extract_playbook.py --check
+        language: system
+        pass_filenames: false
+        files: \.(py|md)$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,73 @@ Cloud agents only see repo files: put demo instructions in **this file**, the **
 - Pre-commit хуки настроены в `.pre-commit-config.yaml` (ruff, pyright, bandit).
 - `Makefile` содержит все проверки: `make check` запускает полный набор, `make test-fast` — параллельные тесты.
 
+## PLAYBOOK markers — when and how to add
+
+When you implement code or write documentation that introduces a
+**generalizable engineering pattern** — a solution applicable beyond
+this project — you MUST add a PLAYBOOK marker.
+
+### How to recognize a generalizable pattern
+
+Apply the substitution test: rewrite your description without project-specific
+terms ("reflection engine", "session manager", "atman", "experience store").
+If the description still makes sense as a general engineering practice —
+it's generalizable. Add a marker.
+
+If the description becomes meaningless without project terms — it's
+project-specific. Don't add a marker.
+
+### Examples that DESERVE a marker
+
+- "Idempotent long-running async operations via deterministic run keys computed from input parameters"
+- "Append-only data structures with annotation layers instead of mutation for preserving authenticity of original records"
+- "Optimistic concurrency for text documents using last-seen-revision tokens"
+- "Port + adapter + deterministic mock as testable abstraction over LLM-dependent logic"
+- "Outcome-coded events (`outcome=foo_ok` / `outcome=foo_failed reason=bar`) for control flow that needs offline analysis"
+- "Two-tier affective regulation (acute level 1 + homeostasis level 2) for stateful systems"
+
+### Examples that DON'T deserve a marker
+
+- "Service uses asyncio" (standard library, not a pattern)
+- "Tests use pytest fixtures" (framework usage, not a pattern)
+- "Function returns Pydantic model" (idiomatic, not a pattern)
+- "`ReflectionEvent` has `identity_snapshot_id` field" (project-specific data model)
+
+### Marker format
+
+See `docs/development/PLAYBOOK_MARKERS.md` for the syntax.
+
+### Where to put markers
+
+PUT THE MARKER NEXT TO THE CODE OR DOCUMENT THAT ILLUSTRATES THE PATTERN.
+Not in a separate file. The marker should sit in the file where the
+pattern is actually applied.
+
+For Python: as a `# PLAYBOOK-START` / `# PLAYBOOK-END` comment block
+immediately above the function, class, or module-level code that
+implements the pattern.
+
+For Markdown docs: as an HTML comment immediately before the section
+that describes the pattern.
+
+### When in doubt
+
+If you're not sure whether something is generalizable — write a marker
+with `status: draft`. The author will review and either promote to
+`status: refined` or remove. Erring on the side of MORE markers is
+preferred over missing real patterns.
+
+DO NOT add markers for changes that are pure refactoring without
+introducing new conceptual structure.
+
+### Reference: known patterns awaiting markers
+
+If you're working on a component listed in `reports/playbook-candidates.md`,
+check whether the pattern is already marked at the relevant code location.
+If not — add the marker.
+
+---
+
 ## Local Agent Instructions
 
 **For local Cursor agents** (not cloud agents), read the master prompt before starting any work:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint format typecheck security test test-fast test-all test-integration audit check all sync-site-content docs-preview demo-experience demo-factual demo-identity demo-reflection demo-session demo-full-corpus demo-webui demo-experience-fast demo-factual-fast demo-identity-fast demo-reflection-fast demo-session-fast demo-full-corpus-fast demo-webui-fast demo-experience-paced demo-factual-paced demo-identity-paced demo-reflection-paced demo-session-paced demo-full-corpus-paced demo-webui-paced webui demo-e2e-scenario
+.PHONY: lint format typecheck security test test-fast test-all test-integration audit check all sync-site-content docs-preview demo-experience demo-factual demo-identity demo-reflection demo-session demo-full-corpus demo-webui demo-experience-fast demo-factual-fast demo-identity-fast demo-reflection-fast demo-session-fast demo-full-corpus-fast demo-webui-fast demo-experience-paced demo-factual-paced demo-identity-paced demo-reflection-paced demo-session-paced demo-full-corpus-paced demo-webui-paced webui demo-e2e-scenario playbook-extract playbook-check playbook-audit
 
 lint:
 	ruff check src/ tests/ e2e/
@@ -112,3 +112,14 @@ webui:
 # See e2e/scenarios/value_drift_under_pressure.py and docs/features/demo-e2e/README.md.
 demo-e2e-scenario:
 	PYTHONPATH=. python3 e2e/scenarios/value_drift_under_pressure.py
+
+# PLAYBOOK marker extraction and validation.
+# See docs/development/PLAYBOOK_MARKERS.md for syntax and setup.
+playbook-extract:
+	python3 scripts/extract_playbook.py --target ../agent-playbook/raw/extracted-from-atman.md
+
+playbook-check:
+	python3 scripts/extract_playbook.py --check
+
+playbook-audit:
+	python3 scripts/suggest_playbook.py

--- a/docs/development/PLAYBOOK_MARKERS.md
+++ b/docs/development/PLAYBOOK_MARKERS.md
@@ -1,0 +1,195 @@
+# PLAYBOOK Markers Convention
+
+This document defines the syntax and usage rules for **PLAYBOOK markers** — special annotations that AI agents add to source files when they introduce a generalizable engineering pattern.
+
+Markers are automatically extracted by `scripts/extract_playbook.py` and synced to `agent-playbook/raw/extracted-from-atman.md` on every push to `main`.
+
+---
+
+## Purpose
+
+When an AI agent implements code or writes documentation that introduces a pattern applicable beyond this project, it adds a PLAYBOOK marker at the implementation site. The marker travels with the code, not in a separate tracking document.
+
+This approach is designed for a workflow where:
+- **Agents write the code** and recognize patterns at the moment of invention
+- **The author reviews results asynchronously** and doesn't have time to extract patterns manually
+- **Patterns must not require a separate ritual** — they are captured automatically on push
+
+---
+
+## Format for Markdown Files
+
+Use an HTML comment block so the marker does not appear in rendered documentation:
+
+```html
+<!-- PLAYBOOK
+id: idempotent-long-running-operations
+category: design-patterns
+title: Idempotent Long-Running Operations via Deterministic Run Keys
+status: refined
+extends: 06
+since: 2026-04-15
+
+Pattern: compute a deterministic run_key from the operation's input parameters.
+Before executing side effects, check whether a terminal success event with this
+key already exists. If yes — return the existing result. If no — execute and
+persist the success event. The operation becomes safe to retry and replay.
+
+Why generalizable: any scheduled job, batch processor, or async pipeline needs
+this. Exception-based "just retry" loses context; mutable "update a flag"
+creates race conditions. Deterministic keys solve both without distributed locks.
+-->
+```
+
+Place the comment **immediately before the section** that describes or implements the pattern.
+
+---
+
+## Format for Python Files
+
+Use a `# PLAYBOOK-START` / `# PLAYBOOK-END` block:
+
+```python
+# PLAYBOOK-START
+# id: optimistic-concurrency-text-documents
+# category: design-patterns
+# title: Optimistic Concurrency for Text-Layer Updates
+# status: draft
+#
+# Pattern: instead of locking the document on write, callers pass a token
+# (last seen updated_at timestamp). On write, compare token to current state;
+# on mismatch, return OUTCOME=conflict with current state. Caller decides
+# retry or merge.
+#
+# Why generalizable: locking long-running text edits creates serialization
+# stalls in async pipelines. Optimistic concurrency + explicit conflict
+# handling is more robust and requires no distributed lock infrastructure.
+#
+# Trade-offs: callers must handle conflict explicitly (no silent retry).
+# PLAYBOOK-END
+def update_recent_layer(
+    self,
+    narrative_id: UUID,
+    content: str,
+    last_seen_updated_at: datetime,
+) -> NarrativeUpdateResult:
+    ...
+```
+
+Place the block **immediately above** the function, class, or module-level code that implements the pattern.
+
+---
+
+## Field Reference
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | Kebab-case unique identifier. Must be unique across all markers in the repo. |
+| `category` | Yes | One of: `design-patterns` / `process-patterns` / `architecture-decisions` / `failure-modes` / `templates` |
+| `title` | Yes | Human-readable title (used in generated output) |
+| `status` | Yes | One of: `draft` / `refined` / `deprecated` |
+| `extends` | No | Pattern number this marker extends (e.g. `06` for pattern 06) |
+| `since` | No | Date the pattern was first identified (YYYY-MM-DD) |
+
+### Field Values
+
+**`category`:**
+- `design-patterns` — technical design decisions: data models, concurrency, idempotency, testing strategies
+- `process-patterns` — workflow and coordination patterns (task assignment, review, handoffs)
+- `architecture-decisions` — structural choices about component boundaries, ports, adapters
+- `failure-modes` — anti-patterns and how to recognize/prevent them
+- `templates` — reusable document or code structures
+
+**`status`:**
+- `draft` — identified but not yet validated as generalizable; needs author review
+- `refined` — validated, well-described, ready for promotion to `patterns/`
+- `deprecated` — was a pattern, no longer recommended; kept for historical reference
+
+---
+
+## Where to Place Markers
+
+**Rule:** Place the marker **at the implementation site** — the file and location where the pattern is actually applied. Not in a separate tracking document.
+
+| File type | Placement | Example |
+|-----------|-----------|---------|
+| Python `.py` | `# PLAYBOOK-START` block immediately above the implementing function or class | Above `def finish_session(...)` in `session_manager.py` |
+| Markdown `.md` | HTML comment immediately before the section that describes the pattern | Before `### Operational Contracts` in `reflection-engine/README.md` |
+
+---
+
+## Generalizable vs Project-Specific: the Substitution Test
+
+Before adding a marker, apply the **substitution test**: rewrite the pattern description replacing all project-specific terms (component names, domain concepts). If the result still makes sense as a general engineering practice — it is generalizable. Add a marker.
+
+### Examples that DESERVE a marker
+
+- "Compute a deterministic run key from operation inputs; skip if terminal success event exists"
+- "Original records immutable; derived perspectives accumulated in separate append-only list"
+- "Abstract LLM calls behind a port; test against deterministic mock that returns template responses"
+- "Capture emotional context at event time; mark `incomplete` rather than guessing retrospectively"
+- "Structured outcome field instead of exception for predictable non-error results"
+
+### Examples that DO NOT deserve a marker
+
+- "Service uses asyncio" — standard library, not a pattern
+- "Tests use pytest fixtures" — framework usage, not a pattern
+- "Function returns Pydantic model" — idiomatic, not a pattern
+- "`ReflectionEvent` has `identity_snapshot_id` field" — project-specific data model
+- Pure refactoring that moves code without introducing new conceptual structure
+
+### When in doubt
+
+Add a marker with `status: draft`. The author will review and either promote to `status: refined` or remove. **Erring on the side of more markers is preferred over missing real patterns.** The author's review filters false positives.
+
+---
+
+## Validation
+
+Run locally:
+
+```bash
+make playbook-check
+```
+
+This validates all markers without writing any output. Returns exit code 1 if any marker has validation errors (missing required fields, unknown category/status, duplicate IDs).
+
+Run extraction (writes to `../agent-playbook/raw/extracted-from-atman.md`):
+
+```bash
+make playbook-extract
+```
+
+---
+
+## Setup for Automatic Synchronization
+
+The GitHub Action `.github/workflows/playbook-sync.yml` runs `scripts/extract_playbook.py` on every push to `main` that touches `src/`, `docs/`, or `scripts/extract_playbook.py`. It then commits the updated `extracted-from-atman.md` to `agent-playbook/raw/`.
+
+To enable automatic sync:
+
+1. Go to [github.com/settings/tokens](https://github.com/settings/tokens) and create a **Personal Access Token** (classic) with scope `repo` (write access to `agent-playbook`).
+2. In **atman** repo settings → **Secrets and variables** → **Actions** → create a secret named `PLAYBOOK_SYNC_TOKEN` with the token value.
+3. Done. On the next push to `main`, markers will be extracted and synced automatically.
+
+If the secret is not set, the workflow step will fail silently (the extraction step succeeds; only the push to `agent-playbook` fails). No code in `atman` is affected.
+
+---
+
+## Periodic Audit (Optional)
+
+To check whether agents have missed adding markers to recent code changes:
+
+```bash
+make playbook-audit
+```
+
+This runs `scripts/suggest_playbook.py`, which analyzes recent commits through an LLM and suggests where markers should be added. Output is printed to stdout; no files are modified. Default provider: Ollama (free, local). See `scripts/suggest_playbook.py --help` for options.
+
+This is a **manual, on-demand check** — not scheduled. Run it when you want to verify coverage, not as a regular ritual.
+
+---
+
+## Reference: Candidates Awaiting Markers
+
+See `reports/playbook-candidates.md` for the full list of patterns identified in the initial audit but not yet bootstrapped with markers. When working on a listed component, check if the pattern still applies and add a marker at the implementation site.

--- a/reports/playbook-audit-2026-05-07.md
+++ b/reports/playbook-audit-2026-05-07.md
@@ -1,0 +1,237 @@
+# Playbook Audit: Atman → agent-playbook
+
+**Date:** 2026-05-07  
+**Author:** Cursor Cloud Agent  
+**Purpose:** Identify generalizable patterns from Atman implementation for agent-playbook enrichment  
+
+---
+
+## Section A: What Already Exists in agent-playbook
+
+Current version: **0.1.0** (2026-04-30). 5 core patterns + 2 guides + 7 templates. All patterns focus on **process management of AI-agent workflows** — how to organize work, assign tasks, review results, isolate environments, and transfer context.
+
+### Core Patterns (5)
+
+| # | Title | Category | Problem Solved |
+|---|-------|----------|----------------|
+| 01 | Agent Rules Structure | Foundation | How to organize documentation so agents work consistently |
+| 02 | Issue-to-PR Workflow | Process | Async task assignment and review via GitHub without direct access |
+| 03 | Strategic Review | Governance | Maintaining architectural coherence across parallel agent contributions |
+| 04 | Environment Isolation | Infrastructure | Preventing interference between parallel agents (Docker/worktrees) |
+| 05 | Context Handoff | Coordination | Transferring knowledge between agents or across agent sessions |
+
+### Supporting Guides (2)
+
+- **Definition of Done for Agents** — completing criteria, type-specific DoD (features/bugs/refactoring/docs)
+- **Common Agent Failure Modes** — context loss, over-engineering, test theater, boundary violations
+
+### Templates (7)
+
+AGENTS.md, DEVELOPMENT_STANDARD.md, PR template, Feature Request, Bug Report, Work Package, issue templates directory
+
+### Gap Analysis
+
+The playbook covers **process patterns only** — how humans manage agents. It has **no technical design patterns** — how to architect systems that agents build. All patterns would apply to any software project; none are specific to the domain of building autonomous systems or LLM-powered components.
+
+---
+
+## Section B: What is in Atman, Valuable for the Playbook, Not Covered by Existing Patterns
+
+The following patterns were identified from Atman's implementation. Each is stated in project-neutral terms and passes the **substitution test** (description makes sense without Atman-specific words).
+
+### B-01: Idempotent Long-Running Operations via Deterministic Run Keys
+
+**Source:** `docs/features/reflection-engine/README.md` — Operational Contracts; `src/atman/core/services/reflection/`
+
+**Description:** Compute a deterministic `run_key` from the operation's input parameters (date, scope, identity snapshot id). Before executing side effects, check whether a terminal success event with this key already exists in the event store. If yes — return the existing result; if no — execute and persist the success event atomically. The operation becomes safe to retry, replay, and schedule redundantly.
+
+**Why generalizable:** Any long-running job (batch processing, scheduled LLM calls, nightly aggregations, webhook processing) needs this. Exception-based "just catch and retry" loses context; mutable "update a flag" creates race conditions. Deterministic keys solve both.
+
+---
+
+### B-02: Append-Only Records with Annotation Layers
+
+**Source:** `docs/features/experience-store/README.md` — Key Principles §2; `docs/features/reflection-engine/README.md` — Design Decision §2
+
+**Description:** Original records are immutable after creation (no update methods on the core model). Derived perspectives — corrections, reframings, commentary — accumulate in a separate append-only list (`reframing_notes`). Callers always see both the original and all annotations; they can choose which view to use.
+
+**Why generalizable:** Any domain where original records have audit or authenticity value: medical records, financial ledgers, legal documents, content moderation decisions, ML training labels. Mutation loses the "what actually happened" layer. This pattern keeps both.
+
+---
+
+### B-03: Port + Deterministic Mock Adapter for LLM-Dependent Logic
+
+**Source:** `docs/features/reflection-engine/README.md` — Design Decision §1; `src/atman/adapters/reflection/mock_reflection_model.py`
+
+**Description:** Define an abstract port (`ReflectionModel`) that the service depends on. Provide a `MockReflectionModel` that returns template-based, fully deterministic responses based on input content. The mock is not a spy or a stub — it produces semantically meaningful output without any network calls or stochastic behavior. All business logic, including LLM output parsing, error paths, and result routing, is tested against the mock.
+
+**Why generalizable:** Any feature that calls an LLM, embedding model, or other probabilistic service. Without deterministic mocks, tests either skip the integration entirely (low confidence) or hit real APIs (slow, expensive, flaky). This pattern provides a third path: full integration test coverage at unit test speed.
+
+---
+
+### B-04: First-Hand vs Retrospective Data Capture
+
+**Source:** `docs/features/session-manager/README.md` — Key Design Principles §1; `docs/architecture/SYSTEM.md` — Critical change 28.04.2026
+
+**Description:** Capture contextual metadata (emotional state, cognitive load, uncertainty level) **at the moment the event occurs**, not by reconstructing it later from logs. If capture is impossible in the moment, mark the record explicitly as `incomplete_coloring=True` — an honest fallback that preserves what was captured. Retrospective reconstruction is prohibited and produces systematically biased data.
+
+**Why generalizable:** Monitoring systems, user feedback, system observability, any domain where subjective or ephemeral context matters. Post-hoc labeling of events is cheap to implement but produces lower-quality signals. Real-time capture + honest incompleteness flag is harder but produces authentic records.
+
+---
+
+### B-05: Outcome-Coded Events as Control Flow Alternative
+
+**Source:** `docs/features/reflection-engine/README.md` — Operational Contracts (example notes values); `src/atman/core/models/reflection.py`
+
+**Description:** Instead of raising exceptions for predictable non-error outcomes (nothing to process, prerequisite not met, already done), persist an event with a structured `outcome` field: `outcome=daily_ok`, `outcome=daily_skipped reason=no_identity`, `outcome=daily_empty reason=no_experiences`. The outcome acts as a terminal state. Callers, schedulers, and monitoring dashboards can query the event store instead of parsing exception logs.
+
+**Why generalizable:** Scheduled jobs, async pipelines, multi-stage workflows. Exceptions are the wrong primitive for "nothing to do today" — they pollute error logs, complicate retry logic, and prevent offline analysis. Outcome-coded events are structured, queryable, and carry semantic meaning.
+
+---
+
+### B-06: Layered Document Volatility (Core / Recent / Threads)
+
+**Source:** `docs/features/identity-store/README.md` — Key Principles §3; `src/atman/core/models/narrative.py`
+
+**Description:** Structure a living document into layers with explicit volatility contracts: (1) a **core layer** that changes rarely and requires deliberate action; (2) a **recent layer** that is replaced completely after each update cycle; (3) **threads** — named storylines with an explicit lifecycle (opened, updated, closed with reason). Each layer has a different write path, different retention, and different reading semantics.
+
+**Why generalizable:** Any system that maintains a "current state" document for an entity that evolves over time: user profile, project status, agent context, onboarding journey. Mixing stable and ephemeral content in a single blob creates staleness and over-growth. Explicit layer contracts prevent both.
+
+---
+
+### B-07: Honest Empty Bootstrap
+
+**Source:** `docs/features/identity-store/README.md` — Key Principles §1; `src/atman/core/services/identity_service.py`
+
+**Description:** When initializing a stateful system for a new entity, start with a **genuinely empty state** and an honest self-description of that emptiness, rather than pre-seeding with plausible-looking but fabricated initial data. Include explicit `open_questions` about what is not yet known. "Empty with honesty" is a valid and preferable initial state.
+
+**Why generalizable:** Personalization systems, recommendation engines, analytics dashboards, agent personas. Pre-seeded defaults look good in demos but pollute the first real data with noise. A system that admits it knows nothing yet is more trustworthy than one that pretends to know.
+
+---
+
+### B-08: Deterministic Experience ID from Session ID
+
+**Source:** `docs/features/session-manager/README.md` — Integration with Experience Store; `src/atman/core/services/session_manager.py`
+
+**Description:** Derive the persisted record's ID deterministically from the triggering event's ID (e.g., `experience_id = uuid5(NAMESPACE, str(session_id))`). On retry or partial persistence failure, the system will attempt to write the same ID, allowing the storage layer to detect and handle idempotent writes explicitly (upsert or detect-duplicate).
+
+**Why generalizable:** Any event-driven system where the same logical event may attempt to create a persistent record multiple times due to retries, at-least-once delivery, or crash recovery. Random UUIDs on each attempt cause phantom duplicates; deterministic IDs allow idempotent writes.
+
+---
+
+### B-09: Replay-Safe Idempotency Keys for Side Effects
+
+**Source:** `docs/features/reflection-engine/README.md` — Operational Contracts ("Reframing is replay-safe"); `src/atman/core/services/reflection/daily.py`
+
+**Description:** When a process generates side effects (appending notes, sending notifications, updating counters), compute a stable `triggered_by` key for each side effect from the operation's run key and the target record's ID: `triggered_by = f"reflection|{run_key}|reframe|{experience_id}"`. The storage layer enforces uniqueness on this key. Replays count `DUPLICATE_TRIGGERED_BY` outcomes instead of producing duplicate side effects.
+
+**Why generalizable:** Any idempotent event processor that generates multiple side effects per run — webhook handlers, change data capture pipelines, fan-out notifications. Without stable side-effect keys, replay protection on the outer operation doesn't prevent inner duplicate side effects.
+
+---
+
+### B-10: Structured Component Documentation (Status / Architecture / Contracts / Testing / Design Decisions)
+
+**Source:** `docs/features/reflection-engine/README.md` and all feature READMEs in `docs/features/`
+
+**Description:** Every implemented component has a README with these mandatory sections: Status, Architecture (models + services + ports + adapters), Running the Demo, CLI Usage, Key Contracts (what it reads / what it writes), Operational Contracts (invariants, idempotency guarantees, degraded behaviors), Critical Rule, Testing, Design Decisions (each with explicit "Why"), Integration Points, Future Work.
+
+**Why generalizable:** Documentation that is missing the "why" of design decisions forces future agents (or developers) to reverse-engineer intent. The operational contracts section (especially degraded behaviors and edge cases) is almost always missing and almost always valuable. This structure works for any non-trivial component.
+
+---
+
+### B-11: Optimistic Concurrency for Text-Layer Updates
+
+**Source:** `docs/features/session-manager/README.md` — Integration with Narrative Store; `src/atman/core/services/session_manager.py`
+
+**Description:** When updating a document that multiple processes might write concurrently, pass a `last_seen_revision` token (e.g., `updated_at` timestamp) with the write request. On the storage layer, compare token to current state before committing; on mismatch, return a structured conflict outcome. The caller decides whether to retry, merge, or record a conflict event. No distributed locks, no serialization stalls.
+
+**Why generalizable:** Any async pipeline where multiple processes might update the same text resource: narrative documents, configuration files, shared notes, summarized context. Locking is brittle under async reflection pipelines; optimistic concurrency + explicit conflict handling is more robust.
+
+---
+
+### B-12: Salience Decay for Relevance Without Deletion
+
+**Source:** `docs/features/experience-store/README.md` — Key Principles §3; `src/atman/core/services/experience_service.py`
+
+**Description:** Represent the "current importance" of a stored record as a calculated value that decays exponentially with time since last access: `salience = base_salience * exp(-lambda * days_since_access)`, with the decay rate modulated by record properties (e.g., depth of a memory). Importantly: **calculating salience does NOT modify the stored record**. The stored `salience` is the initial value; current salience is computed on read.
+
+**Why generalizable:** Search result ranking, recommendation systems, cache eviction policies, notification prioritization. Hard deletion loses data; fixed weights go stale. Decay-on-read gives time-aware relevance without destructive updates.
+
+---
+
+## Section C: What in the Playbook Could Be Updated (Without Replacing)
+
+### Pattern 01: Agent Rules Structure
+Atman's feature READMEs demonstrate a **structured component documentation template** (Status / Architecture / Key Contracts / Operational Contracts / Design Decisions) that goes beyond generic "add documentation" advice. Pattern 01 could be extended with a subsection: "Layer 3.5: Component Contract Documents — what they should include and why". This supplements, not replaces, the existing DEVELOPMENT_STANDARD.md guidance.
+
+### Pattern 05: Context Handoff
+Atman's `docs/architecture/SYSTEM_MAP.md` is a maintained inventory of all modules, integrations, user scenarios, edge cases, and known regressions — updated in the same PR as the code that changes it. This is a concrete implementation of "Layer 4: Current State" from Pattern 05, with a specific structure that has proven useful. Could be added as a named sub-pattern: "System Map as Living Current-State Document".
+
+---
+
+## Section D: Proposed New Patterns
+
+The following 10 patterns are proposed for `agent-playbook/patterns/`. Each is universal — describable without Atman-specific terminology.
+
+### 06: Idempotent Long-Running Operations
+**Summary:** Make batch jobs, scheduled workers, and async pipelines safe to retry by computing a deterministic run key from input parameters and persisting a terminal success event before returning.  
+**Key insight:** Idempotency via deterministic keys is fundamentally different from "just retry and ignore errors" — it gives callers a queryable history of what happened.
+
+### 07: Append-Only Records with Annotation Layers
+**Summary:** Keep original records immutable; accumulate derived perspectives in a separate append-only annotations list. Callers get both raw data and all interpretations.  
+**Key insight:** The "what actually happened" layer has fundamentally different integrity requirements from the "what we think it means" layer.
+
+### 08: Port + Deterministic Mock Adapter for External Dependencies
+**Summary:** Abstract probabilistic external dependencies (LLMs, APIs, sensors) behind ports; provide a deterministic mock that returns semantically meaningful output for testing. Not a stub — a real integration test path without network calls.  
+**Key insight:** Most LLM-powered features have untested business logic because tests skip the LLM entirely. Deterministic mocks remove this tradeoff.
+
+### 09: First-Hand Data Capture with Explicit Incompleteness Flag
+**Summary:** Capture contextual metadata at the moment of the event, not retrospectively. If in-the-moment capture fails, mark the record `incomplete_coloring=True` rather than guessing or omitting.  
+**Key insight:** Post-hoc reconstruction is always biased by later context. An honest incompleteness flag is more useful than a plausible-looking but fabricated value.
+
+### 10: Outcome-Coded Events for Structured Control Flow
+**Summary:** Represent predictable non-error outcomes as structured events with an `outcome` field and optional `reason`. Schedulers, callers, and dashboards query events instead of parsing exception logs.  
+**Key insight:** Exceptions are the wrong primitive for "nothing to process today." Outcome-coded events are observable, structured, and semantically meaningful.
+
+### 11: Layered Document Volatility
+**Summary:** Structure living documents into layers with different volatility contracts: stable core (rarely changes), ephemeral recent (replaced each cycle), and named threads (explicit lifecycle). Write paths, retention, and reading semantics differ per layer.  
+**Key insight:** Mixing stable identity with ephemeral session data causes either stale context or over-growth. Explicit layer contracts let callers know what to trust.
+
+### 12: Honest Empty Bootstrap
+**Summary:** Initialize stateful entities with a genuinely empty state and explicit acknowledgment of what is unknown, rather than pre-seeding with plausible defaults. Include open questions as first-class fields.  
+**Key insight:** Pre-seeded defaults produce phantom data that pollutes early real observations. Honest emptiness is a valid — and more trustworthy — starting state.
+
+### 13: Replay-Safe Side Effect Keys
+**Summary:** Compute a stable idempotency key for each side effect from the triggering operation's run key and target record ID. The storage layer enforces uniqueness on this key; replays count duplicates instead of re-executing.  
+**Key insight:** Outer-operation idempotency without inner-side-effect keys causes duplicate emails, appended notes, incremented counters on replay.
+
+### 14: Salience Decay for Time-Aware Relevance
+**Summary:** Calculate relevance as a function of time since last access and record properties, decaying exponentially. Store the initial salience; compute current salience on read. Do not delete records with low salience.  
+**Key insight:** Static importance scores go stale; hard deletion loses data. Decay-on-read gives time-aware relevance with zero destructive writes.
+
+### 15: Deterministic ID Derivation for Idempotent Persistence
+**Summary:** Derive a persisted record's ID deterministically from the triggering event's ID (UUID v5 or hash). On retry, the same ID is produced, making duplicate-detection at the storage layer trivial.  
+**Key insight:** Random IDs on each attempt create phantom duplicates in at-least-once delivery systems. Deterministic IDs collapse retries to a single canonical record.
+
+---
+
+## Section E: Open Questions for the Author
+
+**E-01: Patterns 11 (Layered Document Volatility) vs Pattern 05 (Context Handoff)**  
+Pattern 11 is technically generalizable, but its natural home might be as an extension of existing Pattern 05 ("Layer 3.5: Layered Document Structure") rather than a standalone pattern. Should it be a sub-section of 05 or a standalone 11? I lean toward standalone because the write semantics (different paths per layer) are the key insight, which is absent from Pattern 05.
+
+**E-02: Pattern 08 (Deterministic Mock Adapter) — scope**  
+The current draft covers LLM mocks specifically. Should it also cover other probabilistic/slow dependencies (embedding APIs, web scrapers, time-based randomness)? The pattern works equally well for all of them. Broadening would make it more universal but less focused.
+
+**E-03: Patterns 13 and 15 — merge or keep separate?**  
+Patterns 13 (Replay-Safe Side Effect Keys) and 15 (Deterministic ID Derivation) both address replay safety through deterministic keys, but at different granularities: 15 is about the root record, 13 is about each side effect generated by a process. They could be merged into one "Deterministic Keys for Idempotent Systems" pattern, or kept separate for clarity. Suggest merging unless both need standalone examples.
+
+**E-04: Pattern 12 (Honest Empty Bootstrap) — is it an anti-pattern document rather than a pattern?**  
+The substance of Pattern 12 is "don't pre-seed with fake defaults." This might read better as an addition to the Failure Modes guide (`guides/failure-modes.md` — a new section "Phantom Seed Data") rather than a standalone pattern. Your call on whether it deserves pattern-level prominence.
+
+**E-05: Two-tier regulation (acute + homeostatic) and 4-level intervention hierarchy**  
+Both are mentioned in `docs/architecture/SYSTEM.md` as planned components but are not yet implemented. Are these patterns mature enough to document now as "planned architecture" patterns, or should we wait for an implementation to validate them first? I've excluded them from Section D for now.
+
+---
+
+*End of audit report. Sections A–E cover the full state of both repositories as of 2026-05-07.*

--- a/reports/playbook-candidates.md
+++ b/reports/playbook-candidates.md
@@ -1,0 +1,107 @@
+# Playbook Candidates Awaiting Markers
+
+These are generalizable patterns identified during the initial audit
+(see `reports/playbook-audit-2026-05-07.md`, Section B) but not yet
+bootstrapped with PLAYBOOK markers.
+
+**When working on a listed component:** check if the pattern still applies
+and add a marker at the implementation site using the syntax in
+`docs/development/PLAYBOOK_MARKERS.md`.
+
+Suggested marker text is provided for each candidate to make it easy to
+add the marker when you encounter the code.
+
+---
+
+## Component: Experience Store
+
+- [ ] **Salience decay via exponential function**
+  - Location: `src/atman/core/services/experience_service.py`
+  - Candidate id: `salience-decay-relevance`
+  - Suggested title: Salience Decay for Time-Aware Relevance Without Deletion
+  - Category: `design-patterns`
+  - Body: "Calculate record relevance as `base_salience * exp(-lambda * days_since_access)` with the decay rate modulated by record depth/intensity. Store the initial salience; compute current salience on read. Do NOT modify the stored record. Why: hard deletion loses data; static scores go stale; decay-on-read gives time-aware relevance with zero destructive writes."
+
+- [ ] **Incomplete coloring flag as honest fallback**
+  - Location: `src/atman/core/models/experience.py` — `KeyMoment.incomplete_coloring`
+  - Candidate id: `incomplete-data-honest-flag`
+  - Suggested title: Explicit Incompleteness Flag as Honest Data Quality Fallback
+  - Category: `design-patterns`
+  - Body: "When contextual metadata cannot be captured in the moment (emotional state, cognitive load, sensor reading), mark the record with an explicit `incomplete_coloring=True` flag rather than guessing or omitting. A record that admits incompleteness is more trustworthy than a fabricated value. Why: post-hoc reconstruction is biased by later context; honest flags preserve signal quality."
+
+---
+
+## Component: Session Manager
+
+- [ ] **First-hand vs retrospective data capture**
+  - Location: `src/atman/core/services/session_manager.py`
+  - Candidate id: `first-hand-data-capture`
+  - Suggested title: First-Hand Data Capture at Event Time vs Retrospective Reconstruction
+  - Category: `design-patterns`
+  - Body: "Capture contextual metadata (emotional state, cognitive load, relevance signal) at the moment the event occurs, not by reconstructing it later from logs. If in-the-moment capture fails, mark the record explicitly as incomplete rather than guessing. Why: monitoring systems, labeling pipelines, and observability stacks all produce lower-quality signals when context is reconstructed after the fact."
+
+- [ ] **Deterministic experience ID from session ID**
+  - Location: `src/atman/core/services/session_manager.py` — `finish_session`
+  - Candidate id: `deterministic-id-from-triggering-event`
+  - Suggested title: Deterministic Record ID Derived from Triggering Event ID
+  - Category: `design-patterns`
+  - Body: "Derive the persisted record's ID deterministically from the triggering event's ID (e.g., UUID v5 namespace + session_id). On retry after partial persistence failure, the same ID is produced, allowing the storage layer to detect duplicate writes. Why: random IDs on each attempt create phantom duplicates in at-least-once delivery systems."
+
+---
+
+## Component: Reflection Engine
+
+- [ ] **Outcome-coded events instead of exceptions**
+  - Location: `src/atman/core/services/reflection/daily.py` and `deep.py`
+  - Candidate id: `outcome-coded-events`
+  - Suggested title: Outcome-Coded Events for Structured Control Flow
+  - Category: `design-patterns`
+  - Body: "Instead of raising exceptions for predictable non-error outcomes (nothing to process, prerequisite not met, already done), persist a structured event with an `outcome` field: `outcome=daily_ok`, `outcome=daily_skipped reason=no_identity`. The outcome is a terminal state, queryable offline. Why: exceptions are the wrong primitive for 'nothing to do today' — they pollute error logs, complicate retry logic, and prevent structured analysis."
+
+- [ ] **Replay-safe side effect keys**
+  - Location: `src/atman/core/services/reflection/daily.py` — reframing logic
+  - Candidate id: `replay-safe-side-effect-keys`
+  - Suggested title: Stable Idempotency Keys for Side Effects Within Idempotent Operations
+  - Category: `design-patterns`
+  - Body: "When an idempotent operation generates multiple side effects (appended notes, notifications, counter increments), compute a stable `triggered_by` key for each side effect: `triggered_by = f'{operation_run_key}|{side_effect_type}|{target_id}'`. The storage layer enforces uniqueness on this key; replays count `DUPLICATE_TRIGGERED_BY` outcomes. Why: outer-operation idempotency without inner-side-effect keys causes duplicate side effects on replay."
+
+- [ ] **Optimistic concurrency for text layer updates**
+  - Location: `src/atman/core/services/session_manager.py` — narrative recent layer update
+  - Candidate id: `optimistic-concurrency-text-documents`
+  - Suggested title: Optimistic Concurrency for Async Text-Layer Updates
+  - Category: `design-patterns`
+  - Body: "Pass a `last_seen_updated_at` token with text document write requests. On write, compare token to current state; on mismatch, return a structured conflict outcome rather than silently overwriting. Caller decides retry or merge. Why: locking long-lived async text edits creates serialization stalls; optimistic concurrency requires no distributed lock infrastructure."
+
+---
+
+## Component: Identity Store
+
+- [ ] **Honest empty bootstrap**
+  - Location: `src/atman/core/services/identity_service.py` — `bootstrap_identity`
+  - Candidate id: `honest-empty-bootstrap`
+  - Suggested title: Honest Empty Bootstrap for Stateful Entities
+  - Category: `design-patterns`
+  - Body: "Initialize a stateful entity with a genuinely empty state and an explicit honest self-description of that emptiness, rather than pre-seeding with plausible-looking defaults. Include explicit `open_questions` as first-class fields. Why: pre-seeded defaults produce phantom data that pollutes early real observations; a system that admits it knows nothing is more trustworthy."
+
+- [ ] **Three-layer document volatility**
+  - Location: `src/atman/core/models/narrative.py` — `NarrativeDocument`
+  - Candidate id: `layered-document-volatility`
+  - Suggested title: Layered Document Volatility (Stable Core / Ephemeral Recent / Named Threads)
+  - Category: `design-patterns`
+  - Body: "Structure living documents into layers with explicit volatility contracts: (1) a core layer that changes rarely and requires deliberate action; (2) a recent layer replaced completely each cycle; (3) named threads with explicit lifecycle (opened → updated → closed with reason). Each layer has a different write path and retention contract. Why: mixing stable identity with ephemeral session data in one blob causes stale context or unbounded growth."
+
+---
+
+## Architecture-level candidates
+
+- [ ] **Component README structure (Status/Architecture/Contracts/Design Decisions)**
+  - Location: `docs/features/reflection-engine/README.md` — template for all feature READMEs
+  - Candidate id: `component-readme-structure`
+  - Suggested title: Structured Component Documentation Template
+  - Category: `templates`
+  - Body: "Every non-trivial component has a README with these sections: Status, Architecture (models/services/ports/adapters), Running the Demo, CLI Usage, Key Contracts (reads/writes), Operational Contracts (invariants/idempotency/degraded behaviors), Critical Rule, Testing, Design Decisions (each with 'Why'), Integration Points, Future Work. Why: documentation missing the 'why' forces future readers to reverse-engineer intent; operational contracts section is almost always missing and almost always valuable."
+
+---
+
+*Generated from audit: `reports/playbook-audit-2026-05-07.md`*  
+*Last updated: 2026-05-07*

--- a/scripts/extract_playbook.py
+++ b/scripts/extract_playbook.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""
+Extract PLAYBOOK markers from Atman source files and generate a consolidated
+output file for agent-playbook/raw/.
+
+Usage:
+    python scripts/extract_playbook.py [options]
+
+Options:
+    --source-repo PATH   Root of the source repository (default: current dir)
+    --target PATH        Output file path (default: ../agent-playbook/raw/extracted-from-atman.md)
+    --check              Validate markers only, do not write output (exit 1 on errors)
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+VALID_CATEGORIES = {
+    "design-patterns",
+    "process-patterns",
+    "architecture-decisions",
+    "failure-modes",
+    "templates",
+}
+
+VALID_STATUSES = {"draft", "refined", "deprecated"}
+
+REQUIRED_FIELDS = {"id", "category", "title", "status"}
+OPTIONAL_FIELDS = {"extends", "since"}
+ALL_FIELDS = REQUIRED_FIELDS | OPTIONAL_FIELDS
+
+IGNORED_DIRS = {".git", ".venv", "venv", "node_modules", "__pycache__", ".mypy_cache", ".ruff_cache"}
+
+
+@dataclass
+class PlaybookMarker:
+    source_file: str
+    source_line: int
+    id: str
+    category: str
+    title: str
+    status: str
+    extends: str = ""
+    since: str = ""
+    body: str = ""
+
+
+@dataclass
+class ExtractionResult:
+    markers: list[PlaybookMarker] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+def _is_ignored(path: Path, repo_root: Path) -> bool:
+    """Return True if any component of the path (relative to repo root) is in IGNORED_DIRS."""
+    try:
+        rel = path.relative_to(repo_root)
+    except ValueError:
+        return False
+    return any(part in IGNORED_DIRS for part in rel.parts)
+
+
+def _read_gitignore_patterns(repo_root: Path) -> list[re.Pattern[str]]:
+    """Read .gitignore and compile patterns (simplified: only path prefix matching)."""
+    gitignore = repo_root / ".gitignore"
+    patterns: list[re.Pattern[str]] = []
+    if not gitignore.exists():
+        return patterns
+    for raw_line in gitignore.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        # Convert simple glob patterns to regex (best-effort, not full gitignore spec)
+        escaped = re.escape(line.rstrip("/"))
+        escaped = escaped.replace(r"\*\*", ".*").replace(r"\*", "[^/]*")
+        try:
+            patterns.append(re.compile(escaped))
+        except re.error:
+            pass
+    return patterns
+
+
+def _is_gitignored(path: Path, repo_root: Path, patterns: list[re.Pattern[str]]) -> bool:
+    try:
+        rel = str(path.relative_to(repo_root))
+    except ValueError:
+        return False
+    return any(p.search(rel) for p in patterns)
+
+
+def _strip_fenced_code_blocks(content: str) -> str:
+    """Replace content inside fenced code blocks with whitespace-preserving placeholders.
+
+    This prevents markers in example code blocks from being extracted as real markers.
+    Line count is preserved so source line numbers remain accurate.
+    """
+    result = []
+    in_fence = False
+    fence_char = ""
+    for line in content.splitlines(keepends=True):
+        stripped = line.strip()
+        if not in_fence:
+            if stripped.startswith("```") or stripped.startswith("~~~"):
+                in_fence = True
+                fence_char = stripped[:3]
+                result.append(line)  # keep the opening fence line
+            else:
+                result.append(line)
+        else:
+            if stripped.startswith(fence_char):
+                in_fence = False
+                result.append(line)  # keep the closing fence line
+            else:
+                # Replace line content with same-length whitespace to preserve line numbers
+                result.append("\n")
+    return "".join(result)
+
+
+def _extract_from_markdown(content: str, source_file: str) -> tuple[list[PlaybookMarker], list[str]]:
+    """Extract PLAYBOOK markers from HTML comments in Markdown files."""
+    markers: list[PlaybookMarker] = []
+    errors: list[str] = []
+
+    # Remove content inside code blocks so example markers are not extracted
+    processed = _strip_fenced_code_blocks(content)
+
+    pattern = re.compile(
+        r"<!--\s*PLAYBOOK\s*\n(.*?)-->",
+        re.DOTALL,
+    )
+
+    for match in pattern.finditer(processed):
+        # Determine approximate line number
+        start_pos = match.start()
+        line_num = processed[:start_pos].count("\n") + 1
+
+        raw_block = match.group(1)
+        marker, errs = _parse_marker_block(raw_block, source_file, line_num)
+        errors.extend(errs)
+        if marker is not None:
+            markers.append(marker)
+
+    return markers, errors
+
+
+def _extract_from_python(content: str, source_file: str) -> tuple[list[PlaybookMarker], list[str]]:
+    """Extract PLAYBOOK markers from # PLAYBOOK-START / # PLAYBOOK-END blocks in Python files."""
+    markers: list[PlaybookMarker] = []
+    errors: list[str] = []
+
+    pattern = re.compile(
+        r"^#\s*PLAYBOOK-START\s*\n((?:#[^\n]*\n)*?)#\s*PLAYBOOK-END",
+        re.MULTILINE,
+    )
+
+    for match in pattern.finditer(content):
+        start_pos = match.start()
+        line_num = content[:start_pos].count("\n") + 1
+
+        raw_block = match.group(1)
+        # Strip leading "# " from each line
+        stripped_lines = []
+        for line in raw_block.splitlines():
+            stripped = re.sub(r"^#\s?", "", line)
+            stripped_lines.append(stripped)
+        clean_block = "\n".join(stripped_lines)
+
+        marker, errs = _parse_marker_block(clean_block, source_file, line_num)
+        errors.extend(errs)
+        if marker is not None:
+            markers.append(marker)
+
+    return markers, errors
+
+
+def _parse_marker_block(
+    block: str, source_file: str, line_num: int
+) -> tuple[PlaybookMarker | None, list[str]]:
+    """Parse a raw marker block into a PlaybookMarker. Returns (marker, errors)."""
+    errors: list[str] = []
+    fields: dict[str, str] = {}
+    body_lines: list[str] = []
+
+    # Parse key: value lines at the start, then treat rest as body text
+    in_fields = True
+    for line in block.splitlines():
+        if in_fields:
+            kv_match = re.match(r"^([\w-]+)\s*:\s*(.*)$", line.strip())
+            if kv_match:
+                key = kv_match.group(1).lower()
+                value = kv_match.group(2).strip()
+                if key in ALL_FIELDS:
+                    fields[key] = value
+                # else: silently ignore unknown structured fields
+                continue
+            else:
+                # First non-field line starts the body
+                in_fields = False
+        if not in_fields:
+            body_lines.append(line)
+
+    # Validate required fields
+    for req in REQUIRED_FIELDS:
+        if req not in fields or not fields[req]:
+            errors.append(
+                f"{source_file}:{line_num}: missing required field '{req}' in PLAYBOOK marker"
+            )
+
+    if "category" in fields and fields["category"] not in VALID_CATEGORIES:
+        errors.append(
+            f"{source_file}:{line_num}: invalid category '{fields['category']}'; "
+            f"must be one of {sorted(VALID_CATEGORIES)}"
+        )
+
+    if "status" in fields and fields["status"] not in VALID_STATUSES:
+        errors.append(
+            f"{source_file}:{line_num}: invalid status '{fields['status']}'; "
+            f"must be one of {sorted(VALID_STATUSES)}"
+        )
+
+    if errors:
+        return None, errors
+
+    marker = PlaybookMarker(
+        source_file=source_file,
+        source_line=line_num,
+        id=fields["id"],
+        category=fields["category"],
+        title=fields["title"],
+        status=fields["status"],
+        extends=fields.get("extends", ""),
+        since=fields.get("since", ""),
+        body="\n".join(body_lines).strip(),
+    )
+    return marker, []
+
+
+def extract_markers(repo_root: Path) -> ExtractionResult:
+    """Walk repo_root and extract all PLAYBOOK markers from .md and .py files."""
+    result = ExtractionResult()
+    gitignore_patterns = _read_gitignore_patterns(repo_root)
+    seen_ids: dict[str, str] = {}  # id -> source location
+
+    for path in sorted(repo_root.rglob("*")):
+        if not path.is_file():
+            continue
+        if _is_ignored(path, repo_root):
+            continue
+        if _is_gitignored(path, repo_root, gitignore_patterns):
+            continue
+        if path.suffix not in (".md", ".py"):
+            continue
+
+        try:
+            content = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+
+        rel_path = str(path.relative_to(repo_root))
+
+        if path.suffix == ".md":
+            markers, errors = _extract_from_markdown(content, rel_path)
+        else:
+            markers, errors = _extract_from_python(content, rel_path)
+
+        result.errors.extend(errors)
+
+        for marker in markers:
+            if marker.id in seen_ids:
+                result.errors.append(
+                    f"{rel_path}:{marker.source_line}: duplicate PLAYBOOK id '{marker.id}' "
+                    f"(first seen at {seen_ids[marker.id]})"
+                )
+            else:
+                seen_ids[marker.id] = f"{rel_path}:{marker.source_line}"
+                result.markers.append(marker)
+
+    return result
+
+
+def _get_current_commit(repo_root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+        )
+        return result.stdout.strip() if result.returncode == 0 else "unknown"
+    except OSError:
+        return "unknown"
+
+
+def generate_output(markers: list[PlaybookMarker], repo_root: Path) -> str:
+    """Generate the Markdown output for agent-playbook/raw/extracted-from-atman.md."""
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    commit = _get_current_commit(repo_root)
+
+    lines: list[str] = [
+        "# Extracted from atman",
+        "",
+        f"Last updated: {now}  ",
+        "Source repo: github.com/hleserg/atman  ",
+        f"Source commit: {commit}",
+        "",
+        "This file is auto-generated. Do not edit directly.",
+        "Edit PLAYBOOK markers in atman source files instead.",
+        "",
+    ]
+
+    if not markers:
+        lines.append("*(No PLAYBOOK markers found)*")
+        return "\n".join(lines)
+
+    # Group by category
+    by_category: dict[str, list[PlaybookMarker]] = {}
+    for m in markers:
+        by_category.setdefault(m.category, []).append(m)
+
+    for category in sorted(by_category):
+        lines.append(f"## {category}")
+        lines.append("")
+        for marker in sorted(by_category[category], key=lambda m: m.id):
+            lines.append(f"### {marker.id}")
+            lines.append(f"**Status**: {marker.status}  ")
+            lines.append(f"**Title**: {marker.title}  ")
+            lines.append(f"**Source**: {marker.source_file}:{marker.source_line}  ")
+            if marker.extends:
+                lines.append(f"**Extends**: {marker.extends}  ")
+            if marker.since:
+                lines.append(f"**Since**: {marker.since}  ")
+            if marker.body:
+                lines.append("")
+                lines.append(marker.body)
+            lines.append("")
+            lines.append("---")
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Extract PLAYBOOK markers from Atman source files.")
+    parser.add_argument(
+        "--source-repo",
+        type=Path,
+        default=Path("."),
+        help="Root of the source repository (default: current directory)",
+    )
+    parser.add_argument(
+        "--target",
+        type=Path,
+        default=Path("../agent-playbook/raw/extracted-from-atman.md"),
+        help="Output file path",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Validate markers only, do not write output. Exit 1 on validation errors.",
+    )
+    args = parser.parse_args()
+
+    repo_root = args.source_repo.resolve()
+    if not repo_root.is_dir():
+        print(f"ERROR: --source-repo path does not exist: {repo_root}", file=sys.stderr)
+        return 1
+
+    result = extract_markers(repo_root)
+
+    if result.errors:
+        for err in result.errors:
+            print(f"ERROR: {err}", file=sys.stderr)
+        print(
+            f"\n{len(result.errors)} validation error(s). No output written.",
+            file=sys.stderr,
+        )
+        return 1
+
+    marker_count = len(result.markers)
+    category_counts = {}
+    for m in result.markers:
+        category_counts[m.category] = category_counts.get(m.category, 0) + 1
+
+    if args.check:
+        print(
+            f"OK: {marker_count} PLAYBOOK marker(s) found, all valid.",
+            file=sys.stderr,
+        )
+        for cat, count in sorted(category_counts.items()):
+            print(f"  {cat}: {count}", file=sys.stderr)
+        return 0
+
+    # Write output
+    output = generate_output(result.markers, repo_root)
+    target = args.target.resolve()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(output, encoding="utf-8")
+
+    print(f"OK: extracted {marker_count} marker(s) to {target}", file=sys.stderr)
+    for cat, count in sorted(category_counts.items()):
+        print(f"  {cat}: {count}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/extract_playbook.py
+++ b/scripts/extract_playbook.py
@@ -15,13 +15,13 @@ Options:
 from __future__ import annotations
 
 import argparse
+import contextlib
 import re
 import subprocess
 import sys
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-
 
 VALID_CATEGORIES = {
     "design-patterns",
@@ -81,10 +81,8 @@ def _read_gitignore_patterns(repo_root: Path) -> list[re.Pattern[str]]:
         # Convert simple glob patterns to regex (best-effort, not full gitignore spec)
         escaped = re.escape(line.rstrip("/"))
         escaped = escaped.replace(r"\*\*", ".*").replace(r"\*", "[^/]*")
-        try:
-            patterns.append(re.compile(escaped))
-        except re.error:
-            pass
+        with contextlib.suppress(re.error):
+                patterns.append(re.compile(escaped))
     return patterns
 
 
@@ -157,7 +155,7 @@ def _extract_from_python(content: str, source_file: str) -> tuple[list[PlaybookM
     errors: list[str] = []
 
     pattern = re.compile(
-        r"^#\s*PLAYBOOK-START\s*\n((?:#[^\n]*\n)*?)#\s*PLAYBOOK-END",
+        r"^[ \t]*#\s*PLAYBOOK-START\s*\n((?:[ \t]*#[^\n]*\n)*?)[ \t]*#\s*PLAYBOOK-END",
         re.MULTILINE,
     )
 
@@ -166,10 +164,10 @@ def _extract_from_python(content: str, source_file: str) -> tuple[list[PlaybookM
         line_num = content[:start_pos].count("\n") + 1
 
         raw_block = match.group(1)
-        # Strip leading "# " from each line
+        # Strip leading whitespace and "# " from each line
         stripped_lines = []
         for line in raw_block.splitlines():
-            stripped = re.sub(r"^#\s?", "", line)
+            stripped = re.sub(r"^[ \t]*#\s?", "", line)
             stripped_lines.append(stripped)
         clean_block = "\n".join(stripped_lines)
 
@@ -301,7 +299,7 @@ def _get_current_commit(repo_root: Path) -> str:
 
 def generate_output(markers: list[PlaybookMarker], repo_root: Path) -> str:
     """Generate the Markdown output for agent-playbook/raw/extracted-from-atman.md."""
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    now = datetime.now(UTC).strftime("%Y-%m-%d")
     commit = _get_current_commit(repo_root)
 
     lines: list[str] = [

--- a/scripts/suggest_playbook.py
+++ b/scripts/suggest_playbook.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""
+Suggest PLAYBOOK markers for recent commits that may have missed them.
+
+Analyzes git log diffs through an LLM and identifies changes that introduce
+generalizable engineering patterns without PLAYBOOK markers.
+
+This script is MANUAL and OPTIONAL. Run it when you want to verify that
+agents have not missed any markers. It does NOT modify files — output only.
+
+Usage:
+    python scripts/suggest_playbook.py [options]
+
+Options:
+    --days N             Analyze commits from last N days (default: 30)
+    --provider           LLM provider: ollama | claude (default: ollama)
+    --ollama-model       Ollama model name (default: llama3.1:8b)
+    --claude-model       Anthropic model (default: claude-haiku-4-5)
+    --ollama-url         Ollama API URL (default: http://localhost:11434)
+    --source-repo PATH   Repo root (default: current directory)
+    --raw-markers PATH   Path to extracted markers file for context
+                         (default: ../agent-playbook/raw/extracted-from-atman.md)
+    --max-diff-chars N   Truncate diff at N characters to fit context (default: 12000)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import textwrap
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+
+def _get_recent_commits(repo_root: Path, days: int) -> list[dict[str, str]]:
+    """Return list of {hash, message, diff} for commits in last N days."""
+    since = (datetime.now(UTC) - timedelta(days=days)).strftime("%Y-%m-%d")
+    result = subprocess.run(
+        ["git", "log", f"--since={since}", "--format=%H|%s", "--name-only"],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        return []
+
+    commits = []
+    lines = result.stdout.strip().splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if "|" in line:
+            parts = line.split("|", 1)
+            commit_hash = parts[0]
+            message = parts[1] if len(parts) > 1 else ""
+            i += 1
+            # Collect changed files until next commit or end
+            changed_files = []
+            while i < len(lines) and "|" not in lines[i] and lines[i].strip():
+                changed_files.append(lines[i].strip())
+                i += 1
+            # Skip blank separator
+            while i < len(lines) and not lines[i].strip():
+                i += 1
+
+            # Get diff for this commit
+            diff_result = subprocess.run(
+                [
+                    "git",
+                    "show",
+                    "--stat",
+                    "--patch",
+                    "--unified=3",
+                    commit_hash,
+                    "--",
+                    "src/",
+                    "docs/",
+                ],
+                capture_output=True,
+                text=True,
+                cwd=repo_root,
+            )
+            diff = diff_result.stdout if diff_result.returncode == 0 else ""
+
+            commits.append(
+                {
+                    "hash": commit_hash[:8],
+                    "message": message,
+                    "files": changed_files,
+                    "diff": diff,
+                }
+            )
+        else:
+            i += 1
+
+    return commits
+
+
+def _read_existing_marker_ids(raw_markers_path: Path) -> list[str]:
+    """Extract existing marker IDs from the extracted markers file."""
+    if not raw_markers_path.exists():
+        return []
+    ids = []
+    for line in raw_markers_path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("### "):
+            marker_id = line[4:].strip()
+            if marker_id:
+                ids.append(marker_id)
+    return ids
+
+
+def _build_prompt(
+    commits: list[dict[str, str]], existing_ids: list[str], max_diff_chars: int
+) -> str:
+    """Build the LLM prompt."""
+    commits_text_parts = []
+    total_chars = 0
+    for c in commits:
+        diff_snippet = c["diff"][:max_diff_chars]
+        if len(c["diff"]) > max_diff_chars:
+            diff_snippet += "\n... [diff truncated] ..."
+        part = f"Commit {c['hash']}: {c['message']}\n{diff_snippet}"
+        if total_chars + len(part) > max_diff_chars * 2:
+            commits_text_parts.append("... [remaining commits omitted to fit context] ...")
+            break
+        commits_text_parts.append(part)
+        total_chars += len(part)
+
+    commits_text = "\n\n---\n\n".join(commits_text_parts)
+
+    existing_ids_text = (
+        "\n".join(f"- {mid}" for mid in existing_ids) if existing_ids else "(none yet)"
+    )
+
+    return textwrap.dedent(f"""
+    You are reviewing recent code and documentation changes in the Atman project
+    (a psychological layer for AI agents). The project uses PLAYBOOK markers to
+    flag generalizable engineering patterns applicable beyond this specific project.
+
+    Existing PLAYBOOK marker IDs already in the codebase:
+    {existing_ids_text}
+
+    Your task: analyze the following recent commits and identify changes that
+    introduce generalizable engineering patterns but do NOT have a PLAYBOOK marker.
+
+    For each missed pattern you find:
+    1. Pattern name (concise, kebab-case id)
+    2. File and approximate line where marker should be added
+    3. Suggested marker text (id, category, title, status: draft, 2-3 line body)
+    4. Confidence: high / medium / low
+
+    GENERALIZABLE means: the pattern can be described without project-specific
+    terms ("reflection engine", "atman", "session manager", "experience store",
+    "eigenstate"). Apply the substitution test: replace those terms with generic
+    equivalents. If the resulting description still makes engineering sense — it
+    is generalizable.
+
+    SKIP changes that are:
+    - Pure refactoring without new conceptual structure
+    - Standard idiomatic code (using asyncio, pytest fixtures, Pydantic models)
+    - Project-specific data model changes (adding a field to a model)
+    - Bug fixes without new design patterns
+    - Documentation corrections without new architectural concepts
+
+    Output format for each suggestion:
+    ---
+    PATTERN: <kebab-case-id>
+    FILE: <path>:<approximate_line>
+    CONFIDENCE: high|medium|low
+    MARKER:
+    # id: <kebab-case-id>
+    # category: design-patterns|process-patterns|architecture-decisions|failure-modes|templates
+    # title: <Title>
+    # status: draft
+    #
+    # <2-3 sentences describing the pattern without project-specific terms>
+    ---
+
+    If no patterns are missed, output: NO PATTERNS MISSED
+
+    Recent commits to analyze:
+
+    {commits_text}
+    """).strip()
+
+
+def _call_ollama(prompt: str, model: str, base_url: str) -> str:
+    """Call Ollama API and return the response text."""
+    try:
+        import urllib.request
+
+        payload = json.dumps(
+            {
+                "model": model,
+                "prompt": prompt,
+                "stream": False,
+            }
+        ).encode("utf-8")
+
+        req = urllib.request.Request(
+            f"{base_url.rstrip('/')}/api/generate",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            return data.get("response", "")
+    except Exception as e:
+        print(f"ERROR calling Ollama: {e}", file=sys.stderr)
+        print("Make sure Ollama is running: ollama serve", file=sys.stderr)
+        return ""
+
+
+def _call_claude(prompt: str, model: str) -> str:
+    """Call Anthropic Claude API and return the response text."""
+    try:
+        import anthropic
+
+        client = anthropic.Anthropic()
+        message = client.messages.create(
+            model=model,
+            max_tokens=2048,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return message.content[0].text
+    except ImportError:
+        print(
+            "ERROR: 'anthropic' package not installed. Run: pip install anthropic", file=sys.stderr
+        )
+        return ""
+    except Exception as e:
+        print(f"ERROR calling Claude: {e}", file=sys.stderr)
+        return ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Suggest PLAYBOOK markers for recent commits that may have missed them."
+    )
+    parser.add_argument("--days", type=int, default=30, help="Analyze commits from last N days")
+    parser.add_argument(
+        "--provider",
+        choices=["ollama", "claude"],
+        default="ollama",
+        help="LLM provider (default: ollama)",
+    )
+    parser.add_argument(
+        "--ollama-model",
+        default="llama3.1:8b",
+        help="Ollama model name (default: llama3.1:8b)",
+    )
+    parser.add_argument(
+        "--claude-model",
+        default="claude-haiku-4-5",
+        help="Anthropic model (default: claude-haiku-4-5)",
+    )
+    parser.add_argument(
+        "--ollama-url",
+        default="http://localhost:11434",
+        help="Ollama API base URL",
+    )
+    parser.add_argument(
+        "--source-repo",
+        type=Path,
+        default=Path("."),
+        help="Repository root (default: current directory)",
+    )
+    parser.add_argument(
+        "--raw-markers",
+        type=Path,
+        default=Path("../agent-playbook/raw/extracted-from-atman.md"),
+        help="Path to extracted markers file for context",
+    )
+    parser.add_argument(
+        "--max-diff-chars",
+        type=int,
+        default=12000,
+        help="Truncate diff at N characters (default: 12000)",
+    )
+    args = parser.parse_args()
+
+    repo_root = args.source_repo.resolve()
+    if not repo_root.is_dir():
+        print(f"ERROR: --source-repo path does not exist: {repo_root}", file=sys.stderr)
+        return 1
+
+    print(f"Analyzing commits from last {args.days} day(s)...", file=sys.stderr)
+    commits = _get_recent_commits(repo_root, args.days)
+
+    if not commits:
+        print(f"No commits found in the last {args.days} day(s).", file=sys.stderr)
+        return 0
+
+    print(f"Found {len(commits)} commit(s). Reading existing markers...", file=sys.stderr)
+    existing_ids = _read_existing_marker_ids(args.raw_markers.resolve())
+    print(f"Existing marker IDs: {len(existing_ids)}", file=sys.stderr)
+
+    prompt = _build_prompt(commits, existing_ids, args.max_diff_chars)
+
+    print(f"Calling {args.provider}...", file=sys.stderr)
+    if args.provider == "ollama":
+        response = _call_ollama(prompt, args.ollama_model, args.ollama_url)
+    else:
+        response = _call_claude(prompt, args.claude_model)
+
+    if not response:
+        print("ERROR: No response from LLM provider.", file=sys.stderr)
+        return 1
+
+    print()
+    print("=" * 60)
+    print("PLAYBOOK MARKER SUGGESTIONS")
+    print("=" * 60)
+    print()
+    print(response)
+    print()
+    print("=" * 60)
+    print("NOTE: These are suggestions only. Review each one manually.")
+    print("Add markers to the source code at the indicated locations.")
+    print("Use 'status: draft' — the author will promote or remove.")
+    print("=" * 60)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/atman/adapters/reflection/mock_reflection_model.py
+++ b/src/atman/adapters/reflection/mock_reflection_model.py
@@ -4,6 +4,30 @@ Mock implementation of ReflectionModel for testing.
 This provides deterministic, template-based responses instead of LLM generation.
 Useful for testing reflection logic without external dependencies.
 """
+# PLAYBOOK-START
+# id: port-deterministic-mock-for-llm-dependencies
+# category: design-patterns
+# title: Port + Deterministic Mock Adapter for LLM-Dependent Logic
+# status: refined
+#
+# Pattern: define an abstract port that the service depends on (here:
+# ReflectionModel). Provide a deterministic mock implementation that returns
+# template-based, semantically meaningful responses based on input content —
+# NOT random, NOT a stub that returns empty strings, NOT a spy. The mock
+# exercises the same code paths as a real LLM adapter, including output
+# parsing, error routing, and result handling, but with zero network calls
+# and zero stochastic behavior. All business logic is testable at unit speed.
+#
+# Why generalizable: any feature calling an LLM, embedding model, external
+# API, or other probabilistic service. Without deterministic mocks, tests
+# either skip the integration entirely (low confidence) or hit real APIs
+# (slow, expensive, flaky). This pattern provides a third path: full
+# integration test coverage at unit test speed.
+#
+# Trade-offs: mock must be maintained alongside the real adapter; divergence
+# between mock behavior and real LLM output can hide integration bugs.
+# Mitigate by running a small set of real-API smoke tests separately.
+# PLAYBOOK-END
 
 from atman.core.models.experience import SessionExperience
 from atman.core.models.identity import Identity

--- a/src/atman/core/services/experience_service.py
+++ b/src/atman/core/services/experience_service.py
@@ -72,6 +72,27 @@ class ExperienceService:
         """
         return self.store.get_experience(experience_id)
 
+    # PLAYBOOK-START
+    # id: append-only-records-with-annotation-layers
+    # category: design-patterns
+    # title: Append-Only Records with Annotation Layers
+    # status: refined
+    #
+    # Pattern: original records are immutable after creation — no update methods
+    # exist on the core model. Derived perspectives (corrections, reframings,
+    # commentary) accumulate in a separate append-only list. Callers see both
+    # the original record and all annotations; they can choose which view to use.
+    #
+    # Why generalizable: any domain where original records have audit or
+    # authenticity value — medical records, financial ledgers, legal documents,
+    # content moderation decisions, ML training labels. Mutation loses the
+    # "what actually happened" layer. This pattern keeps both the original and
+    # all derived interpretations without conflict.
+    #
+    # Trade-offs: queries that need "latest value" must walk the annotation list;
+    # storage grows monotonically. Worthwhile when original authenticity matters
+    # more than storage efficiency.
+    # PLAYBOOK-END
     def add_reframing_note(
         self,
         experience_id: UUID,

--- a/src/atman/core/services/reflection_service.py
+++ b/src/atman/core/services/reflection_service.py
@@ -55,6 +55,30 @@ from atman.core.reflection_run_keys import (
 from atman.core.services.narrative_revision import NarrativeRevisionService
 
 
+# PLAYBOOK-START
+# id: idempotent-long-running-operations
+# category: design-patterns
+# title: Idempotent Long-Running Operations via Deterministic Run Keys
+# status: refined
+#
+# Pattern: compute a deterministic run_key from the operation's input
+# parameters (date + identity id + scope). Before executing side effects,
+# check whether a terminal success event with this key already exists in
+# the event store. If yes — return the existing result immediately. If no
+# — execute, then persist the success event with outcome=*_ok / *_empty /
+# *_skipped. The operation is now safe to retry, replay, and schedule
+# redundantly without producing duplicate side effects.
+#
+# Why generalizable: any long-running job (batch processing, scheduled LLM
+# calls, nightly aggregations, webhook processing) needs this. Exception-
+# based "just retry" loses context; mutable "update a status flag" creates
+# race conditions. Deterministic keys + terminal success events solve both
+# without distributed locks or two-phase commits.
+#
+# Trade-offs: requires a queryable event store with run_key index; adds one
+# read before every execution. Worth it whenever the operation has observable
+# side effects that must not be repeated.
+# PLAYBOOK-END
 def _daily_run_terminal_success(notes: str) -> bool:
     return any(
         x in notes for x in ("outcome=daily_ok", "outcome=daily_empty", "outcome=daily_skipped")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## PLAYBOOK markers

- [x] I introduced new generalizable patterns and added PLAYBOOK markers
- [ ] I introduced no generalizable patterns
- [ ] I'm uncertain

---

## Что сделано

Реализована инфраструктура PLAYBOOK-маркеров для автоматического сбора паттернов из Atman в agent-playbook.

### Этап 1: Аудит

- `reports/playbook-audit-2026-05-07.md` — полный аудит обоих репозиториев:
  - **Секция А**: 5 паттернов в agent-playbook (все process-паттерны, нет технических)
  - **Секция Б**: 12 generalizable паттернов из Atman (idempotent runs, append-only, mock adapters, first-hand capture, outcome-coded events и др.)
  - **Секция В**: что в playbook можно дополнить
  - **Секция Г**: 10 предложенных новых паттернов (06–15)
  - **Секция Д**: 5 открытых вопросов для автора

### Этап 3: Синтаксис маркеров

- `docs/development/PLAYBOOK_MARKERS.md` — полная документация формата, substitution test, setup инструкция с PAT

### Этап 4: Механизм извлечения

- `scripts/extract_playbook.py` — парсит `.py` и `.md` файлы, валидирует маркеры, генерирует `extracted-from-atman.md`
- `Makefile` — таргеты `playbook-extract`, `playbook-check`, `playbook-audit`
- `.pre-commit-config.yaml` — добавлен hook `playbook-check` (валидация при каждом коммите)
- `.github/workflows/playbook-sync.yml` — GitHub Action: при push в main автоматически синхронизирует маркеры в agent-playbook

### Этап 5: Инструкции агентам

- `AGENTS.md` — новая секция "PLAYBOOK markers" с substitution test, примерами, ссылками
- `.cursor/rules/playbook-markers.mdc` — напоминание в Cursor IDE
- `.github/pull_request_template.md` — добавлен чекбокс PLAYBOOK markers
- `reports/playbook-candidates.md` — 9 кандидатов для будущей расстановки маркеров агентами
- **3 bootstrap-маркера** в коде:
  - `src/atman/core/services/experience_service.py` — `append-only-records-with-annotation-layers`
  - `src/atman/adapters/reflection/mock_reflection_model.py` — `port-deterministic-mock-for-llm-dependencies`
  - `src/atman/core/services/reflection_service.py` — `idempotent-long-running-operations`
- `scripts/suggest_playbook.py` — опциональный LLM-аудит (Ollama/Claude, только stdout)

### Этап 2: НЕ выполнен

Создание новых `patterns/06+.md` в agent-playbook требует ответа автора на открытые вопросы из `reports/playbook-audit-2026-05-07.md` Секция Д.

## Как воспроизвести

```bash
# Валидация маркеров (должна вернуть 3 маркера, exit 0)
make playbook-check

# Полное извлечение (требует ../agent-playbook/)
make playbook-extract

# Опциональный LLM-аудит (требует ollama)
make playbook-audit
```

## Тип изменений

- [x] Новая возможность / документация

## Карта системы

- **Затронутые разделы**: §3 — новые точки входа (`make playbook-*`); новые entrypoints в `scripts/`
- **Покрытие тестами**: `make playbook-check` проходит с 3 валидными маркерами
- **Карта обновлена**: N/A (scripts/ не является частью `src/atman/` пакета)

## Тесты-страховки

N/A — PR не затрагивает порты, адаптеры, сериализацию моделей или CLI-команды.

## Чеклист

- [x] `ruff check src/ tests/` — 0 ошибок
- [x] `ruff format --check src/ tests/` — 0 ошибок
- [x] `make playbook-check` — 3 маркера, все валидны
- [x] Все тесты по изменённым компонентам: 126 passed (experience, reflection, session)
- [x] Предварительные сбои (`test_demo_smoke`, `test_tui_units`) — существуют на `main` до PR, не регрессии

## Открытые вопросы для автора (из Секции Д)

1. **Паттерн 11 (Layered Document Volatility)** — самостоятельный паттерн или расширение Pattern 05?
2. **Паттерн 08 (Deterministic Mock)** — только LLM или расширить на все вероятностные зависимости?
3. **Паттерны 13 и 15** (Replay-Safe Keys + Deterministic ID) — объединить в один?
4. **Паттерн 12 (Honest Empty Bootstrap)** — самостоятельный паттерн или раздел в Failure Modes guide?
5. **Two-tier regulation** — документировать сейчас как planned architecture или ждать реализации?

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eba30006-26d7-46d9-b1e2-75589ec9e2b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eba30006-26d7-46d9-b1e2-75589ec9e2b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

