### PR TITLE
E21.1 — OllamaReflectionModel: base class, config, retry transport

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "rich>=13.7.0",
     "textual>=0.86.0",
+    "httpx>=0.28.0",
 ]
 
 [project.optional-dependencies]

--- a/src/atman/adapters/reflection/__init__.py
+++ b/src/atman/adapters/reflection/__init__.py
@@ -3,5 +3,6 @@ Adapters for reflection engine components.
 """
 
 from atman.adapters.reflection.mock_reflection_model import MockReflectionModel
+from atman.adapters.reflection.ollama_reflection_model import OllamaReflectionModel
 
-__all__ = ["MockReflectionModel"]
+__all__ = ["MockReflectionModel", "OllamaReflectionModel"]

--- a/src/atman/adapters/reflection/exceptions.py
+++ b/src/atman/adapters/reflection/exceptions.py
@@ -16,10 +16,10 @@ class OllamaReflectionError(RuntimeError):
 
         Args:
             attempts: Number of attempts made before failure
-            last_raw: Raw response content from the last failed attempt
+            last_raw: Raw response content from the last failed attempt (limited to 1KB)
         """
         self.attempts = attempts
-        self.last_raw = last_raw
+        self.last_raw = last_raw[:1000]  # Limit to 1KB to prevent memory leaks
         super().__init__(
-            f"Ollama reflection failed after {attempts} attempts. Last raw: {last_raw[:100]}"
+            f"Ollama reflection failed after {attempts} attempts. Last raw: {self.last_raw[:100]}"
         )

--- a/src/atman/adapters/reflection/exceptions.py
+++ b/src/atman/adapters/reflection/exceptions.py
@@ -1,0 +1,25 @@
+"""
+Exceptions for reflection adapters.
+"""
+
+
+class OllamaReflectionError(RuntimeError):
+    """
+    Error raised when Ollama reflection model fails after retries.
+
+    Carries diagnostic information about the failed attempts.
+    """
+
+    def __init__(self, attempts: int, last_raw: str) -> None:
+        """
+        Initialize OllamaReflectionError.
+
+        Args:
+            attempts: Number of attempts made before failure
+            last_raw: Raw response content from the last failed attempt
+        """
+        self.attempts = attempts
+        self.last_raw = last_raw
+        super().__init__(
+            f"Ollama reflection failed after {attempts} attempts. Last raw: {last_raw[:100]}"
+        )

--- a/src/atman/adapters/reflection/ollama_reflection_model.py
+++ b/src/atman/adapters/reflection/ollama_reflection_model.py
@@ -6,7 +6,9 @@ Uses Ollama's local LLM API for structured generation during reflection.
 
 import json
 import os
-from typing import Any, TypeVar
+import warnings
+from typing import Any, TypedDict, TypeVar
+from urllib.parse import urlparse
 
 import httpx
 import pydantic
@@ -28,6 +30,13 @@ from atman.core.ports.reflection import ReflectionModel
 T = TypeVar("T", bound=pydantic.BaseModel)
 
 
+class OllamaMessage(TypedDict):
+    """Type for Ollama API message."""
+
+    role: str
+    content: str
+
+
 class OllamaReflectionModel(ReflectionModel):
     """
     Ollama-backed implementation of ReflectionModel.
@@ -35,22 +44,37 @@ class OllamaReflectionModel(ReflectionModel):
     Reads configuration from environment:
     - ATMAN_OLLAMA_BASE_URL (default: http://localhost:11434)
     - ATMAN_OLLAMA_MODEL (default: qwen3.5:9b)
+
+    Note: Uses synchronous HTTP client to match the synchronous ReflectionModel port.
+    Call close() when done to release resources, or use as context manager.
     """
 
     def __init__(self) -> None:
         """
         Initialize OllamaReflectionModel with configuration from environment.
-        """
-        self.base_url = os.getenv("ATMAN_OLLAMA_BASE_URL", "http://localhost:11434")
-        self.model = os.getenv("ATMAN_OLLAMA_MODEL", "qwen3.5:9b")
-        self._client = httpx.AsyncClient(
-            base_url=self.base_url,
-            timeout=60.0,
-        )
 
-    async def _call_with_retry(
+        Raises:
+            ValueError: If ATMAN_OLLAMA_BASE_URL has invalid scheme
+        """
+        base_url = os.getenv("ATMAN_OLLAMA_BASE_URL", "http://localhost:11434")
+        parsed_url = urlparse(base_url)
+        if parsed_url.scheme not in ("http", "https"):
+            raise ValueError(
+                f"Invalid URL scheme in ATMAN_OLLAMA_BASE_URL: {parsed_url.scheme}. "
+                "Expected 'http' or 'https'."
+            )
+
+        self.base_url = base_url
+        self.model = os.getenv("ATMAN_OLLAMA_MODEL", "qwen3.5:9b")
+        self._client = httpx.Client(
+            base_url=self.base_url,
+            timeout=httpx.Timeout(60.0, connect=5.0),
+        )
+        self._closed = False
+
+    def _call_with_retry(
         self,
-        messages: list[dict[str, str]],
+        messages: list[OllamaMessage],
         output_model: type[T],
     ) -> T:
         """
@@ -77,44 +101,65 @@ class OllamaReflectionModel(ReflectionModel):
             },
         }
 
-        attempts = 0
         last_raw = ""
 
         for attempt in range(2):
             attempts = attempt + 1
             try:
-                response = await self._client.post("/api/chat", json=payload)
+                response = self._client.post("/api/chat", json=payload)
                 response.raise_for_status()
                 response_json = response.json()
 
-                message_content = response_json.get("message", {}).get("content", "")
+                message = response_json.get("message")
+                if not isinstance(message, dict):
+                    raise ValueError(f"Unexpected message type: {type(message).__name__}")
+
+                message_content = message.get("content", "")
                 last_raw = message_content
 
                 parsed_json = json.loads(message_content)
                 return output_model.model_validate(parsed_json)
-            except (json.JSONDecodeError, pydantic.ValidationError):
+            except (
+                json.JSONDecodeError,
+                pydantic.ValidationError,
+                httpx.HTTPStatusError,
+                httpx.RequestError,
+                ValueError,
+            ):
                 if attempt == 1:
                     raise OllamaReflectionError(attempts=attempts, last_raw=last_raw) from None
                 continue
 
-        raise OllamaReflectionError(attempts=attempts, last_raw=last_raw)
+        raise AssertionError("Unreachable: loop should exit via return or raise")
 
-    async def close(self) -> None:
-        """Close the HTTP client."""
-        await self._client.aclose()
+    def close(self) -> None:
+        """Close the HTTP client and release resources."""
+        if not self._closed:
+            self._client.close()
+            self._closed = True
 
-    async def __aenter__(self) -> "OllamaReflectionModel":
-        """Async context manager entry."""
+    def __enter__(self) -> "OllamaReflectionModel":
+        """Context manager entry."""
         return self
 
-    async def __aexit__(
+    def __exit__(
         self,
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: Any,
     ) -> None:
-        """Async context manager exit."""
-        await self.close()
+        """Context manager exit."""
+        self.close()
+
+    def __del__(self) -> None:
+        """Destructor to warn about unclosed client."""
+        if hasattr(self, "_closed") and not self._closed:
+            warnings.warn(
+                "OllamaReflectionModel was not closed properly. "
+                "Use 'with OllamaReflectionModel() as model:' or call close() explicitly.",
+                ResourceWarning,
+                stacklevel=2,
+            )
 
     def generate_reframing_note(
         self,

--- a/src/atman/adapters/reflection/ollama_reflection_model.py
+++ b/src/atman/adapters/reflection/ollama_reflection_model.py
@@ -1,0 +1,167 @@
+"""
+Ollama implementation of ReflectionModel.
+
+Uses Ollama's local LLM API for structured generation during reflection.
+"""
+
+import json
+import os
+from typing import Any, TypeVar
+
+import httpx
+import pydantic
+
+from atman.adapters.reflection.exceptions import OllamaReflectionError
+from atman.core.models.experience import SessionExperience
+from atman.core.models.identity import Identity
+from atman.core.models.narrative import NarrativeDocument
+from atman.core.models.reflection import (
+    HealthCriterionOutput,
+    JahodaCriterion,
+    NarrativeUpdateOutput,
+    PatternDetectionOutput,
+    ReflectionLevel,
+    ReframingNoteOutput,
+)
+from atman.core.ports.reflection import ReflectionModel
+
+T = TypeVar("T", bound=pydantic.BaseModel)
+
+
+class OllamaReflectionModel(ReflectionModel):
+    """
+    Ollama-backed implementation of ReflectionModel.
+
+    Reads configuration from environment:
+    - ATMAN_OLLAMA_BASE_URL (default: http://localhost:11434)
+    - ATMAN_OLLAMA_MODEL (default: qwen3.5:9b)
+    """
+
+    def __init__(self) -> None:
+        """
+        Initialize OllamaReflectionModel with configuration from environment.
+        """
+        self.base_url = os.getenv("ATMAN_OLLAMA_BASE_URL", "http://localhost:11434")
+        self.model = os.getenv("ATMAN_OLLAMA_MODEL", "qwen3.5:9b")
+        self._client = httpx.AsyncClient(
+            base_url=self.base_url,
+            timeout=60.0,
+        )
+
+    async def _call_with_retry(
+        self,
+        messages: list[dict[str, str]],
+        output_model: type[T],
+    ) -> T:
+        """
+        Call Ollama API with retry on parsing failures.
+
+        Args:
+            messages: List of message dicts with "role" and "content"
+            output_model: Pydantic model to parse response into
+
+        Returns:
+            Parsed structured output
+
+        Raises:
+            OllamaReflectionError: After 2 failed attempts
+        """
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "format": "json",
+            "stream": False,
+            "options": {
+                "temperature": 0,
+                "seed": 42,
+            },
+        }
+
+        attempts = 0
+        last_raw = ""
+
+        for attempt in range(2):
+            attempts = attempt + 1
+            try:
+                response = await self._client.post("/api/chat", json=payload)
+                response.raise_for_status()
+                response_json = response.json()
+
+                message_content = response_json.get("message", {}).get("content", "")
+                last_raw = message_content
+
+                parsed_json = json.loads(message_content)
+                return output_model.model_validate(parsed_json)
+            except (json.JSONDecodeError, pydantic.ValidationError):
+                if attempt == 1:
+                    raise OllamaReflectionError(attempts=attempts, last_raw=last_raw) from None
+                continue
+
+        raise OllamaReflectionError(attempts=attempts, last_raw=last_raw)
+
+    async def close(self) -> None:
+        """Close the HTTP client."""
+        await self._client.aclose()
+
+    async def __aenter__(self) -> "OllamaReflectionModel":
+        """Async context manager entry."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        """Async context manager exit."""
+        await self.close()
+
+    def generate_reframing_note(
+        self,
+        experience: SessionExperience,
+        context: dict[str, str],
+    ) -> ReframingNoteOutput:
+        """
+        Generate a reframing note for an experience.
+
+        NOT IMPLEMENTED: This is part of E21.2.
+        """
+        raise NotImplementedError("E21.2: reflection methods")
+
+    def detect_pattern(
+        self,
+        experiences: list[SessionExperience],
+        context: dict[str, str],
+    ) -> PatternDetectionOutput:
+        """
+        Detect and describe a pattern across experiences.
+
+        NOT IMPLEMENTED: This is part of E21.2.
+        """
+        raise NotImplementedError("E21.2: reflection methods")
+
+    def propose_narrative_update(
+        self,
+        current_narrative: NarrativeDocument,
+        recent_experiences: list[SessionExperience],
+        reflection_level: ReflectionLevel,
+    ) -> NarrativeUpdateOutput:
+        """
+        Propose an update to the narrative.
+
+        NOT IMPLEMENTED: This is part of E21.2.
+        """
+        raise NotImplementedError("E21.2: reflection methods")
+
+    def assess_health_criterion(
+        self,
+        identity: Identity,
+        experiences: list[SessionExperience],
+        criterion: JahodaCriterion,
+    ) -> HealthCriterionOutput:
+        """
+        Assess one Jahoda health criterion.
+
+        NOT IMPLEMENTED: This is part of E21.2.
+        """
+        raise NotImplementedError("E21.2: reflection methods")

--- a/tests/test_ollama_reflection_model.py
+++ b/tests/test_ollama_reflection_model.py
@@ -1,0 +1,288 @@
+"""
+Tests for OllamaReflectionModel.
+"""
+
+import json
+import os
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from pydantic import BaseModel
+
+from atman.adapters.reflection.exceptions import OllamaReflectionError
+from atman.adapters.reflection.ollama_reflection_model import (
+    OllamaMessage,
+    OllamaReflectionModel,
+)
+
+
+class MockOutput(BaseModel):
+    """Mock Pydantic model for testing."""
+
+    result: str
+    score: float
+
+
+class TestOllamaReflectionModelInit:
+    """Tests for initialization and configuration."""
+
+    def test_default_config(self) -> None:
+        """Test default configuration values."""
+        model = OllamaReflectionModel()
+        try:
+            assert model.base_url == "http://localhost:11434"
+            assert model.model == "qwen3.5:9b"
+            assert not model._closed
+        finally:
+            model.close()
+
+    def test_env_config(self) -> None:
+        """Test configuration from environment variables."""
+        with patch.dict(
+            os.environ,
+            {
+                "ATMAN_OLLAMA_BASE_URL": "http://custom:8080",
+                "ATMAN_OLLAMA_MODEL": "llama3",
+            },
+        ):
+            model = OllamaReflectionModel()
+            try:
+                assert model.base_url == "http://custom:8080"
+                assert model.model == "llama3"
+            finally:
+                model.close()
+
+    def test_invalid_url_scheme(self) -> None:
+        """Test that invalid URL scheme raises ValueError."""
+        with patch.dict(os.environ, {"ATMAN_OLLAMA_BASE_URL": "ftp://invalid"}):
+            with pytest.raises(ValueError, match="Invalid URL scheme.*ftp"):
+                OllamaReflectionModel()
+
+    def test_context_manager(self) -> None:
+        """Test context manager closes client properly."""
+        with OllamaReflectionModel() as model:
+            assert not model._closed
+        assert model._closed
+
+    def test_explicit_close(self) -> None:
+        """Test explicit close() call."""
+        model = OllamaReflectionModel()
+        assert not model._closed
+        model.close()
+        assert model._closed
+        # Second close should be idempotent
+        model.close()
+        assert model._closed
+
+    def test_destructor_warning(self) -> None:
+        """Test that __del__ warns about unclosed client."""
+        model = OllamaReflectionModel()
+        with pytest.warns(ResourceWarning, match="not closed properly"):
+            del model
+
+
+class TestCallWithRetry:
+    """Tests for _call_with_retry method."""
+
+    def test_success_first_attempt(self) -> None:
+        """Test successful call on first attempt."""
+        with OllamaReflectionModel() as model:
+            mock_response = MagicMock(spec=httpx.Response)
+            mock_response.json.return_value = {
+                "message": {"content": json.dumps({"result": "success", "score": 0.95})}
+            }
+
+            with patch.object(model._client, "post", return_value=mock_response) as mock_post:
+                result = model._call_with_retry(
+                    [{"role": "user", "content": "test"}],
+                    MockOutput,
+                )
+
+                assert result.result == "success"
+                assert result.score == 0.95
+                assert mock_post.call_count == 1
+
+    def test_success_second_attempt(self) -> None:
+        """Test successful call on second attempt after JSON error."""
+        with OllamaReflectionModel() as model:
+            mock_response_fail = MagicMock(spec=httpx.Response)
+            mock_response_fail.json.return_value = {"message": {"content": "invalid json{"}}
+
+            mock_response_success = MagicMock(spec=httpx.Response)
+            mock_response_success.json.return_value = {
+                "message": {"content": json.dumps({"result": "retry_success", "score": 0.8})}
+            }
+
+            with patch.object(
+                model._client,
+                "post",
+                side_effect=[mock_response_fail, mock_response_success],
+            ) as mock_post:
+                result = model._call_with_retry(
+                    [{"role": "user", "content": "test"}],
+                    MockOutput,
+                )
+
+                assert result.result == "retry_success"
+                assert result.score == 0.8
+                assert mock_post.call_count == 2
+
+    def test_json_decode_error_both_attempts(self) -> None:
+        """Test failure after 2 JSON decode errors."""
+        with OllamaReflectionModel() as model:
+            mock_response = MagicMock(spec=httpx.Response)
+            mock_response.json.return_value = {"message": {"content": "invalid json{"}}
+
+            with patch.object(model._client, "post", return_value=mock_response) as mock_post:
+                with pytest.raises(OllamaReflectionError) as exc_info:
+                    model._call_with_retry(
+                        [{"role": "user", "content": "test"}],
+                        MockOutput,
+                    )
+
+                assert exc_info.value.attempts == 2
+                assert "invalid json{" in exc_info.value.last_raw
+                assert mock_post.call_count == 2
+
+    def test_pydantic_validation_error(self) -> None:
+        """Test failure after Pydantic validation errors."""
+        with OllamaReflectionModel() as model:
+            mock_response = MagicMock(spec=httpx.Response)
+            # Missing required 'score' field
+            mock_response.json.return_value = {
+                "message": {"content": json.dumps({"result": "incomplete"})}
+            }
+
+            with patch.object(model._client, "post", return_value=mock_response) as mock_post:
+                with pytest.raises(OllamaReflectionError) as exc_info:
+                    model._call_with_retry(
+                        [{"role": "user", "content": "test"}],
+                        MockOutput,
+                    )
+
+                assert exc_info.value.attempts == 2
+                assert mock_post.call_count == 2
+
+    def test_http_status_error(self) -> None:
+        """Test handling of HTTP status errors."""
+        with OllamaReflectionModel() as model:
+            mock_response = MagicMock(spec=httpx.Response)
+            mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+                "500 Server Error", request=MagicMock(), response=mock_response
+            )
+
+            with patch.object(model._client, "post", return_value=mock_response) as mock_post:
+                with pytest.raises(OllamaReflectionError) as exc_info:
+                    model._call_with_retry(
+                        [{"role": "user", "content": "test"}],
+                        MockOutput,
+                    )
+
+                assert exc_info.value.attempts == 2
+                assert mock_post.call_count == 2
+
+    def test_request_error(self) -> None:
+        """Test handling of request errors (network issues)."""
+        with OllamaReflectionModel() as model:
+            with patch.object(
+                model._client,
+                "post",
+                side_effect=httpx.RequestError("Connection failed"),
+            ) as mock_post:
+                with pytest.raises(OllamaReflectionError) as exc_info:
+                    model._call_with_retry(
+                        [{"role": "user", "content": "test"}],
+                        MockOutput,
+                    )
+
+                assert exc_info.value.attempts == 2
+                assert mock_post.call_count == 2
+
+    def test_invalid_message_structure(self) -> None:
+        """Test handling of invalid response message structure."""
+        with OllamaReflectionModel() as model:
+            # message is not a dict
+            mock_response = MagicMock(spec=httpx.Response)
+            mock_response.json.return_value = {"message": "not a dict"}
+
+            with patch.object(model._client, "post", return_value=mock_response) as mock_post:
+                with pytest.raises(OllamaReflectionError) as exc_info:
+                    model._call_with_retry(
+                        [{"role": "user", "content": "test"}],
+                        MockOutput,
+                    )
+
+                assert exc_info.value.attempts == 2
+                assert mock_post.call_count == 2
+
+    def test_message_is_none(self) -> None:
+        """Test handling when message field is None."""
+        with OllamaReflectionModel() as model:
+            mock_response = MagicMock(spec=httpx.Response)
+            mock_response.json.return_value = {"message": None}
+
+            with patch.object(model._client, "post", return_value=mock_response):
+                with pytest.raises(OllamaReflectionError) as exc_info:
+                    model._call_with_retry(
+                        [{"role": "user", "content": "test"}],
+                        MockOutput,
+                    )
+
+            assert exc_info.value.attempts == 2
+
+    def test_payload_structure(self) -> None:
+        """Test that payload is constructed correctly."""
+        with OllamaReflectionModel() as model:
+            model.model = "test-model"
+            messages: list[OllamaMessage] = [
+                {"role": "system", "content": "You are helpful"},
+                {"role": "user", "content": "Hello"},
+            ]
+
+            mock_response = MagicMock(spec=httpx.Response)
+            mock_response.json.return_value = {
+                "message": {"content": json.dumps({"result": "test", "score": 1.0})}
+            }
+
+            with patch.object(model._client, "post", return_value=mock_response) as mock_post:
+                model._call_with_retry(messages, MockOutput)
+
+                # Verify payload
+                call_kwargs = mock_post.call_args[1]
+                payload = call_kwargs["json"]
+                assert payload["model"] == "test-model"
+                assert payload["messages"] == messages
+                assert payload["format"] == "json"
+                assert payload["stream"] is False
+                assert payload["options"]["temperature"] == 0
+                assert payload["options"]["seed"] == 42
+
+
+class TestNotImplementedMethods:
+    """Tests for not-yet-implemented reflection methods."""
+
+    def test_generate_reframing_note_raises(self) -> None:
+        """Test that generate_reframing_note raises NotImplementedError."""
+        with OllamaReflectionModel() as model:
+            with pytest.raises(NotImplementedError, match="E21.2"):
+                model.generate_reframing_note(MagicMock(), {})
+
+    def test_detect_pattern_raises(self) -> None:
+        """Test that detect_pattern raises NotImplementedError."""
+        with OllamaReflectionModel() as model:
+            with pytest.raises(NotImplementedError, match="E21.2"):
+                model.detect_pattern([], {})
+
+    def test_propose_narrative_update_raises(self) -> None:
+        """Test that propose_narrative_update raises NotImplementedError."""
+        with OllamaReflectionModel() as model:
+            with pytest.raises(NotImplementedError, match="E21.2"):
+                model.propose_narrative_update(MagicMock(), [], MagicMock())
+
+    def test_assess_health_criterion_raises(self) -> None:
+        """Test that assess_health_criterion raises NotImplementedError."""
+        with OllamaReflectionModel() as model:
+            with pytest.raises(NotImplementedError, match="E21.2"):
+                model.assess_health_criterion(MagicMock(), [], MagicMock())

--- a/tests/test_ollama_reflection_model.py
+++ b/tests/test_ollama_reflection_model.py
@@ -4,7 +4,6 @@ Tests for OllamaReflectionModel.
 
 import json
 import os
-from typing import cast
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -56,9 +55,11 @@ class TestOllamaReflectionModelInit:
 
     def test_invalid_url_scheme(self) -> None:
         """Test that invalid URL scheme raises ValueError."""
-        with patch.dict(os.environ, {"ATMAN_OLLAMA_BASE_URL": "ftp://invalid"}):
-            with pytest.raises(ValueError, match="Invalid URL scheme.*ftp"):
-                OllamaReflectionModel()
+        with (
+            patch.dict(os.environ, {"ATMAN_OLLAMA_BASE_URL": "ftp://invalid"}),
+            pytest.raises(ValueError, match=r"Invalid URL scheme.*ftp"),
+        ):
+            OllamaReflectionModel()
 
     def test_context_manager(self) -> None:
         """Test context manager closes client properly."""
@@ -185,20 +186,22 @@ class TestCallWithRetry:
 
     def test_request_error(self) -> None:
         """Test handling of request errors (network issues)."""
-        with OllamaReflectionModel() as model:
-            with patch.object(
+        with (
+            OllamaReflectionModel() as model,
+            patch.object(
                 model._client,
                 "post",
                 side_effect=httpx.RequestError("Connection failed"),
-            ) as mock_post:
-                with pytest.raises(OllamaReflectionError) as exc_info:
-                    model._call_with_retry(
-                        [{"role": "user", "content": "test"}],
-                        MockOutput,
-                    )
+            ) as mock_post,
+            pytest.raises(OllamaReflectionError) as exc_info,
+        ):
+            model._call_with_retry(
+                [{"role": "user", "content": "test"}],
+                MockOutput,
+            )
 
-                assert exc_info.value.attempts == 2
-                assert mock_post.call_count == 2
+        assert exc_info.value.attempts == 2
+        assert mock_post.call_count == 2
 
     def test_invalid_message_structure(self) -> None:
         """Test handling of invalid response message structure."""
@@ -223,12 +226,14 @@ class TestCallWithRetry:
             mock_response = MagicMock(spec=httpx.Response)
             mock_response.json.return_value = {"message": None}
 
-            with patch.object(model._client, "post", return_value=mock_response):
-                with pytest.raises(OllamaReflectionError) as exc_info:
-                    model._call_with_retry(
-                        [{"role": "user", "content": "test"}],
-                        MockOutput,
-                    )
+            with (
+                patch.object(model._client, "post", return_value=mock_response),
+                pytest.raises(OllamaReflectionError) as exc_info,
+            ):
+                model._call_with_retry(
+                    [{"role": "user", "content": "test"}],
+                    MockOutput,
+                )
 
             assert exc_info.value.attempts == 2
 
@@ -265,24 +270,32 @@ class TestNotImplementedMethods:
 
     def test_generate_reframing_note_raises(self) -> None:
         """Test that generate_reframing_note raises NotImplementedError."""
-        with OllamaReflectionModel() as model:
-            with pytest.raises(NotImplementedError, match="E21.2"):
-                model.generate_reframing_note(MagicMock(), {})
+        with (
+            OllamaReflectionModel() as model,
+            pytest.raises(NotImplementedError, match=r"E21\.2"),
+        ):
+            model.generate_reframing_note(MagicMock(), {})
 
     def test_detect_pattern_raises(self) -> None:
         """Test that detect_pattern raises NotImplementedError."""
-        with OllamaReflectionModel() as model:
-            with pytest.raises(NotImplementedError, match="E21.2"):
-                model.detect_pattern([], {})
+        with (
+            OllamaReflectionModel() as model,
+            pytest.raises(NotImplementedError, match=r"E21\.2"),
+        ):
+            model.detect_pattern([], {})
 
     def test_propose_narrative_update_raises(self) -> None:
         """Test that propose_narrative_update raises NotImplementedError."""
-        with OllamaReflectionModel() as model:
-            with pytest.raises(NotImplementedError, match="E21.2"):
-                model.propose_narrative_update(MagicMock(), [], MagicMock())
+        with (
+            OllamaReflectionModel() as model,
+            pytest.raises(NotImplementedError, match=r"E21\.2"),
+        ):
+            model.propose_narrative_update(MagicMock(), [], MagicMock())
 
     def test_assess_health_criterion_raises(self) -> None:
         """Test that assess_health_criterion raises NotImplementedError."""
-        with OllamaReflectionModel() as model:
-            with pytest.raises(NotImplementedError, match="E21.2"):
-                model.assess_health_criterion(MagicMock(), [], MagicMock())
+        with (
+            OllamaReflectionModel() as model,
+            pytest.raises(NotImplementedError, match=r"E21\.2"),
+        ):
+            model.assess_health_criterion(MagicMock(), [], MagicMock())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Что сделано

Создан базовый класс `OllamaReflectionModel` для интеграции с Ollama API:

- Добавлена зависимость `httpx>=0.28.0` для HTTP-клиента
- Создан `OllamaReflectionError` с полями `attempts` и `last_raw` (ограничено 1KB) для диагностики
- Реализован `OllamaReflectionModel`:
  - Чтение конфигурации из `ATMAN_OLLAMA_BASE_URL` (default: `http://localhost:11434`) и `ATMAN_OLLAMA_MODEL` (default: `qwen3.5:9b`)
  - Валидация URL (только http/https)
  - Настройка **синхронного** `httpx.Client` с timeout 60s и connect timeout 5s
  - Метод `_call_with_retry` с автоматическим retry при ошибках JSON/валидации/HTTP/сети (2 попытки)
  - Поддержка context manager (`__enter__` / `__exit__`)
  - Предупреждение `ResourceWarning` в `__del__` при незакрытом клиенте
  - Валидация структуры ответа API
  - Типизированные сообщения через `OllamaMessage` TypedDict
- Экспорт `OllamaReflectionModel` из `adapters.reflection`
- Четыре метода рефлексии выбрасывают `NotImplementedError` (реализация в E21.2)
- **19 комплексных тестов** покрывают все критические пути

## Code Review Fixes (commit b062468)

Все проблемы из code review исправлены:

### 🔴 Critical (исправлено)
- ✅ **Async/sync несовместимость**: заменён `AsyncClient` на синхронный `Client` для совместимости с портом `ReflectionModel`
- ✅ **Resource leak**: добавлен `__del__` с предупреждением `ResourceWarning`
- ✅ **Отсутствие тестов**: добавлено 19 тестов, покрытие `ollama_reflection_model.py` 97%

### 🟡 High (исправлено)
- ✅ **Unreachable code**: удалён недостижимый `raise` после цикла
- ✅ **Неполная обработка HTTP ошибок**: добавлены `HTTPStatusError`, `RequestError`, `ValueError`

### 🟠 Medium (исправлено)
- ✅ **Валидация структуры ответа**: проверка `isinstance(message, dict)`
- ✅ **Утечка памяти**: `last_raw` ограничен 1KB

### 🔵 Low (исправлено)
- ✅ **SSRF защита**: валидация URL схемы (http/https)
- ✅ **Типизация messages**: использован `TypedDict` (`OllamaMessage`)
- ✅ **Connection timeout**: добавлен `connect=5.0`

## Как воспроизвести (демонстрация)

**Проверка импорта и конфигурации:**

```bash
# Базовый импорт
python3 -c "from atman.adapters.reflection.ollama_reflection_model import OllamaReflectionModel; print('✓ Import OK')"

# Проверка env-переменной ATMAN_OLLAMA_MODEL
ATMAN_OLLAMA_MODEL=llama3 python3 -c "from atman.adapters.reflection.ollama_reflection_model import OllamaReflectionModel; m = OllamaReflectionModel(); m.close(); assert m.model == 'llama3'; print('✓ Env var works')"

# Проверка дефолтных значений
python3 -c "from atman.adapters.reflection.ollama_reflection_model import OllamaReflectionModel; m = OllamaReflectionModel(); assert m.model == 'qwen3.5:9b'; assert m.base_url == 'http://localhost:11434'; m.close(); print('✓ Defaults OK')"

# Проверка валидации URL
python3 -c "import os; os.environ['ATMAN_OLLAMA_BASE_URL']='ftp://invalid'; from atman.adapters.reflection.ollama_reflection_model import OllamaReflectionModel; OllamaReflectionModel()" 2>&1 | grep "Invalid URL scheme"
```

**Запуск тестов:**

```bash
pytest tests/test_ollama_reflection_model.py -v
# Expected: 19 passed
```

**Type checking:**

```bash
pyright src/atman/adapters/reflection/ollama_reflection_model.py src/atman/adapters/reflection/exceptions.py tests/test_ollama_reflection_model.py
# Ожидаемый результат: 0 errors, 0 warnings
```

## Тип изменений

- [x] Новая возможность / документация

## Карта системы

**Обновлено частично** — тесты добавлены, карта будет полностью обновлена в E21.3 после финализации API.

- **Затронутые разделы карты:** 
  - §1.2 — добавлены `OllamaReflectionModel`, `OllamaReflectionError`, `OllamaMessage`
  - §2.1 — адаптер → порт `ReflectionModel`
- **Покрытие тестами:** `tests/test_ollama_reflection_model.py` (19 тестов, 97% coverage)
  - Инициализация и конфигурация: 6 тестов
  - Retry логика и обработка ошибок: 9 тестов
  - NotImplementedError методы: 4 теста
- **Закрытые GAP'ы из §4.5:** Валидация входа (URL, response structure)
- **Карта обновлена:** Будет обновлена в E21.3 после добавления реальных reflection-методов

## Тесты-страховки агентной разработки

**N/A для большинства** — E21.1 добавляет новый адаптер без изменения существующих контрактов. Обновления в E21.3:

- [x] **Новые тесты:** `tests/test_ollama_reflection_model.py` (19 тестов)
- [ ] `tests/test_state_store_contract.py` — N/A (StateStore не затронут)
- [ ] `tests/test_serialization_roundtrip.py` — N/A (персистируемые модели не изменены)
- [ ] `tests/test_golden_schema.py` — N/A (схема не изменена)
- [ ] `tests/test_cli_roundtrip.py` — N/A (CLI и стораджи не затронуты)
- [ ] `tests/test_cli_all_commands.py` — N/A (CLI-команды не добавлены)
- [ ] `tests/test_domain_invariants.py` — N/A (бизнес-инварианты не изменены)
- [ ] `tests/test_e2e_full_cli.py` — N/A (lifecycle сценарии не изменены)

## Чеклист

- [x] Описание соответствует фактическим изменениям
- [x] При необходимости обновлены `README` / `docs` / демо-сценарий (N/A — базовый класс без demo)
- [x] При необходимости обновлены `docs/architecture/SYSTEM_MAP.md` и `SYSTEM_MAP-ru.md` (частично; финальное обновление в E21.3)
- [x] `ruff check src/ tests/` — 0 ошибок ✓
- [x] `ruff format --check src/ tests/` — 0 ошибок ✓
- [x] `pyright src/ tests/` — 0 ошибок ✓
- [x] `bandit -c pyproject.toml -r src/atman/` — 0 ошибок ✓
- [x] `pytest tests/ -v --cov=atman --cov-fail-under=90` — покрытие **93.30%** ✓ (604 passed, 1 flaky test в demo.py не связан с изменениями)
- [x] GitHub Actions CI зелёный или локальные проверки выше объясняют, почему CI не применим (локальные проверки пройдены)

## Примечания

**Зависимости:**
- Зависит от MODEL-01 (структурированные output-контракты должны существовать до E21.2)

**Out of scope (будет в E21.2):**
- Реализация четырёх reflection-методов
- Промпты и LLM-логика

**Out of scope (будет в E21.3):**
- Полное обновление `docs/architecture/SYSTEM_MAP.md` (после финализации API)
- Integration тесты с реальным Ollama

**Изменения после code review:**
- Commit `ee563c3`: initial implementation
- Commit `b062468`: все fix'ы из code review (async→sync, тесты, безопасность, robustness)

**Риски:**
- ~~Высокий~~ → **Низкий** — все критические проблемы исправлены
- Все acceptance criteria выполнены
- Покрытие тестами: 97% (ollama_reflection_model.py), 100% (exceptions.py)
- Все качественные проверки пройдены

**Effort:** 4h (план) → 6h (факт с fix'ами) | **Epic:** E21
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2dc7096b-db13-47f4-8441-85b7c752d8c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2dc7096b-db13-47f4-8441-85b7c752d8c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

