### PR TITLE
feat(E21.2): OllamaReflectionModel — four structured-output reflection methods

### DIFF
--- a/src/atman/adapters/reflection/ollama_reflection_model.py
+++ b/src/atman/adapters/reflection/ollama_reflection_model.py
@@ -7,13 +7,20 @@ Uses Ollama's local LLM API for structured generation during reflection.
 import json
 import os
 import warnings
-from typing import Any, TypedDict, TypeVar
+from typing import Any, TypeVar
 from urllib.parse import urlparse
 
 import httpx
 import pydantic
 
 from atman.adapters.reflection.exceptions import OllamaReflectionError
+from atman.adapters.reflection.prompts import (
+    OllamaMessage,
+    build_health_messages,
+    build_narrative_messages,
+    build_pattern_messages,
+    build_reframing_messages,
+)
 from atman.core.models.experience import SessionExperience
 from atman.core.models.identity import Identity
 from atman.core.models.narrative import NarrativeDocument
@@ -28,13 +35,6 @@ from atman.core.models.reflection import (
 from atman.core.ports.reflection import ReflectionModel
 
 T = TypeVar("T", bound=pydantic.BaseModel)
-
-
-class OllamaMessage(TypedDict):
-    """Type for Ollama API message."""
-
-    role: str
-    content: str
 
 
 class OllamaReflectionModel(ReflectionModel):
@@ -166,24 +166,18 @@ class OllamaReflectionModel(ReflectionModel):
         experience: SessionExperience,
         context: dict[str, str],
     ) -> ReframingNoteOutput:
-        """
-        Generate a reframing note for an experience.
-
-        NOT IMPLEMENTED: This is part of E21.2.
-        """
-        raise NotImplementedError("E21.2: reflection methods")
+        """Generate a reframing note for an experience via Ollama."""
+        messages = build_reframing_messages(experience, context)
+        return self._call_with_retry(messages, ReframingNoteOutput)
 
     def detect_pattern(
         self,
         experiences: list[SessionExperience],
         context: dict[str, str],
     ) -> PatternDetectionOutput:
-        """
-        Detect and describe a pattern across experiences.
-
-        NOT IMPLEMENTED: This is part of E21.2.
-        """
-        raise NotImplementedError("E21.2: reflection methods")
+        """Detect and describe a pattern across experiences via Ollama."""
+        messages = build_pattern_messages(experiences, context)
+        return self._call_with_retry(messages, PatternDetectionOutput)
 
     def propose_narrative_update(
         self,
@@ -191,12 +185,13 @@ class OllamaReflectionModel(ReflectionModel):
         recent_experiences: list[SessionExperience],
         reflection_level: ReflectionLevel,
     ) -> NarrativeUpdateOutput:
-        """
-        Propose an update to the narrative.
-
-        NOT IMPLEMENTED: This is part of E21.2.
-        """
-        raise NotImplementedError("E21.2: reflection methods")
+        """Propose an update to the narrative via Ollama."""
+        messages = build_narrative_messages(
+            current_narrative,
+            recent_experiences,
+            reflection_level,
+        )
+        return self._call_with_retry(messages, NarrativeUpdateOutput)
 
     def assess_health_criterion(
         self,
@@ -204,9 +199,6 @@ class OllamaReflectionModel(ReflectionModel):
         experiences: list[SessionExperience],
         criterion: JahodaCriterion,
     ) -> HealthCriterionOutput:
-        """
-        Assess one Jahoda health criterion.
-
-        NOT IMPLEMENTED: This is part of E21.2.
-        """
-        raise NotImplementedError("E21.2: reflection methods")
+        """Assess one Jahoda health criterion via Ollama."""
+        messages = build_health_messages(identity, experiences, criterion)
+        return self._call_with_retry(messages, HealthCriterionOutput)

--- a/src/atman/adapters/reflection/prompts.py
+++ b/src/atman/adapters/reflection/prompts.py
@@ -1,0 +1,236 @@
+"""
+Prompt templates for OllamaReflectionModel.
+
+Each function builds a list of Ollama messages (system + user) for one
+ReflectionModel method.  System prompts embed the JSON schema of the
+expected output model so the LLM knows the exact structure to produce.
+"""
+
+import json
+from typing import TypedDict
+
+import pydantic
+
+from atman.core.models.experience import SessionExperience
+from atman.core.models.identity import Identity
+from atman.core.models.narrative import NarrativeDocument
+from atman.core.models.reflection import (
+    HealthCriterionOutput,
+    JahodaCriterion,
+    NarrativeUpdateOutput,
+    PatternDetectionOutput,
+    ReflectionLevel,
+    ReframingNoteOutput,
+)
+
+
+class OllamaMessage(TypedDict):
+    """Type for Ollama API message."""
+
+    role: str
+    content: str
+
+
+# ---------------------------------------------------------------------------
+# Type alias used by callers
+# ---------------------------------------------------------------------------
+OllamaMessages = list[OllamaMessage]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _schema_block(model: type[pydantic.BaseModel]) -> str:
+    """Return a compact JSON-schema string for *model*."""
+    return json.dumps(model.model_json_schema(), indent=2)
+
+
+def _experience_summary(exp: SessionExperience) -> str:
+    """Compact textual summary of a single experience for prompt inclusion."""
+    lines: list[str] = [f"Session {exp.session_id} ({exp.timestamp.isoformat()})"]
+    for km in exp.key_moments:
+        valence = km.how_i_felt.emotional_valence
+        intensity = km.how_i_felt.emotional_intensity
+        lines.append(
+            f"  - {km.what_happened} "
+            f"(valence={valence:+.2f}, intensity={intensity:.2f}, "
+            f"depth={km.how_i_felt.depth.value})"
+        )
+        if km.values_touched:
+            lines.append(f"    values touched: {', '.join(km.values_touched)}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# 1. generate_reframing_note
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT_REFRAMING = """\
+You are the introspective layer of an AI agent performing micro-reflection.
+
+Given an experience and optional context, produce a reframing note — a new
+perspective or insight about the experience.
+
+Respond ONLY with valid JSON matching this schema (no preamble, no markdown):
+{schema}
+"""
+
+
+def build_reframing_messages(
+    experience: SessionExperience,
+    context: dict[str, str],
+    output_model: type[ReframingNoteOutput] = ReframingNoteOutput,
+) -> OllamaMessages:
+    """Build Ollama messages for :meth:`generate_reframing_note`."""
+    system = SYSTEM_PROMPT_REFRAMING.format(schema=_schema_block(output_model))
+
+    user_parts = [
+        "## Experience",
+        _experience_summary(experience),
+    ]
+    if context:
+        user_parts.append("\n## Context")
+        for key, value in context.items():
+            user_parts.append(f"- {key}: {value}")
+
+    return [
+        OllamaMessage(role="system", content=system),
+        OllamaMessage(role="user", content="\n".join(user_parts)),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 2. detect_pattern
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT_PATTERN = """\
+You are the analytical layer of an AI agent performing pattern detection.
+
+Given a set of experiences and optional context, detect a recurring behavioral,
+emotional, or cognitive pattern.  If no clear pattern exists, return an empty
+description.
+
+Respond ONLY with valid JSON matching this schema (no preamble, no markdown):
+{schema}
+"""
+
+
+def build_pattern_messages(
+    experiences: list[SessionExperience],
+    context: dict[str, str],
+    output_model: type[PatternDetectionOutput] = PatternDetectionOutput,
+) -> OllamaMessages:
+    """Build Ollama messages for :meth:`detect_pattern`."""
+    system = SYSTEM_PROMPT_PATTERN.format(schema=_schema_block(output_model))
+
+    user_parts = ["## Experiences"]
+    for exp in experiences:
+        user_parts.append(_experience_summary(exp))
+        user_parts.append("")
+
+    if context:
+        user_parts.append("## Context")
+        for key, value in context.items():
+            user_parts.append(f"- {key}: {value}")
+
+    return [
+        OllamaMessage(role="system", content=system),
+        OllamaMessage(role="user", content="\n".join(user_parts)),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 3. propose_narrative_update
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT_NARRATIVE = """\
+You are the narrative layer of an AI agent updating its self-narrative.
+
+Given the current narrative document and recent experiences, propose an update
+to the narrative.  The body should be written in first person and reflect what
+the agent has learned or experienced.
+
+Reflection level: {level}
+
+Respond ONLY with valid JSON matching this schema (no preamble, no markdown):
+{schema}
+"""
+
+
+def build_narrative_messages(
+    current_narrative: NarrativeDocument,
+    recent_experiences: list[SessionExperience],
+    reflection_level: ReflectionLevel,
+    output_model: type[NarrativeUpdateOutput] = NarrativeUpdateOutput,
+) -> OllamaMessages:
+    """Build Ollama messages for :meth:`propose_narrative_update`."""
+    system = SYSTEM_PROMPT_NARRATIVE.format(
+        level=reflection_level.value,
+        schema=_schema_block(output_model),
+    )
+
+    user_parts = [
+        "## Current Narrative",
+        f"Core layer: {current_narrative.core_layer.content}",
+        f"Recent layer: {current_narrative.recent_layer.content}",
+        "",
+        "## Recent Experiences",
+    ]
+    for exp in recent_experiences:
+        user_parts.append(_experience_summary(exp))
+        user_parts.append("")
+
+    return [
+        OllamaMessage(role="system", content=system),
+        OllamaMessage(role="user", content="\n".join(user_parts)),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 4. assess_health_criterion
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT_HEALTH = """\
+You are the psychological health assessment layer of an AI agent.
+
+Assess the agent on the Jahoda criterion: **{criterion}**.
+Use the identity and recent experiences as evidence.
+
+Respond ONLY with valid JSON matching this schema (no preamble, no markdown):
+{schema}
+"""
+
+
+def build_health_messages(
+    identity: Identity,
+    experiences: list[SessionExperience],
+    criterion: JahodaCriterion,
+    output_model: type[HealthCriterionOutput] = HealthCriterionOutput,
+) -> OllamaMessages:
+    """Build Ollama messages for :meth:`assess_health_criterion`."""
+    system = SYSTEM_PROMPT_HEALTH.format(
+        criterion=criterion.value,
+        schema=_schema_block(output_model),
+    )
+
+    user_parts = [
+        "## Identity",
+        f"Self-description: {identity.self_description}",
+    ]
+    if identity.core_values:
+        user_parts.append("Core values: " + ", ".join(v.name for v in identity.core_values))
+    if identity.principles:
+        user_parts.append("Principles: " + ", ".join(p.statement for p in identity.principles))
+
+    user_parts.append("")
+    user_parts.append("## Recent Experiences")
+    for exp in experiences:
+        user_parts.append(_experience_summary(exp))
+        user_parts.append("")
+
+    return [
+        OllamaMessage(role="system", content=system),
+        OllamaMessage(role="user", content="\n".join(user_parts)),
+    ]

--- a/tests/test_ollama_reflection_model.py
+++ b/tests/test_ollama_reflection_model.py
@@ -11,10 +11,8 @@ import pytest
 from pydantic import BaseModel
 
 from atman.adapters.reflection.exceptions import OllamaReflectionError
-from atman.adapters.reflection.ollama_reflection_model import (
-    OllamaMessage,
-    OllamaReflectionModel,
-)
+from atman.adapters.reflection.ollama_reflection_model import OllamaReflectionModel
+from atman.adapters.reflection.prompts import OllamaMessage
 
 
 class MockOutput(BaseModel):
@@ -265,37 +263,84 @@ class TestCallWithRetry:
                 assert payload["options"]["seed"] == 42
 
 
-class TestNotImplementedMethods:
-    """Tests for not-yet-implemented reflection methods."""
+class TestReflectionMethods:
+    """Tests for the four reflection methods delegating to _call_with_retry."""
 
-    def test_generate_reframing_note_raises(self) -> None:
-        """Test that generate_reframing_note raises NotImplementedError."""
+    def _make_mock_response(self, content: str) -> MagicMock:
+        """Create a mock httpx.Response returning *content* as message body."""
+        resp = MagicMock(spec=httpx.Response)
+        resp.json.return_value = {"message": {"content": content}}
+        return resp
+
+    def test_generate_reframing_note(self) -> None:
+        """Test generate_reframing_note delegates to _call_with_retry."""
+        payload = json.dumps({"reflection": "new insight", "reflection_type": "insight"})
+        mock_resp = self._make_mock_response(payload)
+
         with (
             OllamaReflectionModel() as model,
-            pytest.raises(NotImplementedError, match=r"E21\.2"),
+            patch.object(model._client, "post", return_value=mock_resp) as mock_post,
         ):
-            model.generate_reframing_note(MagicMock(), {})
+            result = model.generate_reframing_note(MagicMock(), {})
 
-    def test_detect_pattern_raises(self) -> None:
-        """Test that detect_pattern raises NotImplementedError."""
+            assert result.reflection == "new insight"
+            assert result.reflection_type == "insight"
+            mock_post.assert_called_once()
+
+    def test_detect_pattern(self) -> None:
+        """Test detect_pattern delegates to _call_with_retry."""
+        payload = json.dumps(
+            {
+                "description": "recurring pattern",
+                "confidence": 0.7,
+                "potential_habit": "",
+                "potential_principle": "",
+            }
+        )
+        mock_resp = self._make_mock_response(payload)
+
         with (
             OllamaReflectionModel() as model,
-            pytest.raises(NotImplementedError, match=r"E21\.2"),
+            patch.object(model._client, "post", return_value=mock_resp) as mock_post,
         ):
-            model.detect_pattern([], {})
+            result = model.detect_pattern([], {})
 
-    def test_propose_narrative_update_raises(self) -> None:
-        """Test that propose_narrative_update raises NotImplementedError."""
+            assert result.description == "recurring pattern"
+            assert result.confidence == 0.7
+            mock_post.assert_called_once()
+
+    def test_propose_narrative_update(self) -> None:
+        """Test propose_narrative_update delegates to _call_with_retry."""
+        payload = json.dumps({"body": "updated narrative text"})
+        mock_resp = self._make_mock_response(payload)
+
         with (
             OllamaReflectionModel() as model,
-            pytest.raises(NotImplementedError, match=r"E21\.2"),
+            patch.object(model._client, "post", return_value=mock_resp) as mock_post,
         ):
-            model.propose_narrative_update(MagicMock(), [], MagicMock())
+            result = model.propose_narrative_update(MagicMock(), [], MagicMock())
 
-    def test_assess_health_criterion_raises(self) -> None:
-        """Test that assess_health_criterion raises NotImplementedError."""
+            assert result.body == "updated narrative text"
+            mock_post.assert_called_once()
+
+    def test_assess_health_criterion(self) -> None:
+        """Test assess_health_criterion delegates to _call_with_retry."""
+        payload = json.dumps(
+            {
+                "score": 0.75,
+                "evidence": ["shows growth"],
+                "concerns": ["limited data"],
+            }
+        )
+        mock_resp = self._make_mock_response(payload)
+
         with (
             OllamaReflectionModel() as model,
-            pytest.raises(NotImplementedError, match=r"E21\.2"),
+            patch.object(model._client, "post", return_value=mock_resp) as mock_post,
         ):
-            model.assess_health_criterion(MagicMock(), [], MagicMock())
+            result = model.assess_health_criterion(MagicMock(), [], MagicMock())
+
+            assert result.score == 0.75
+            assert result.evidence == ["shows growth"]
+            assert result.concerns == ["limited data"]
+            mock_post.assert_called_once()


### PR DESCRIPTION
## PLAYBOOK markers

- [ ] I introduced new generalizable patterns and added PLAYBOOK markers
- [x] I introduced no generalizable patterns (pure refactoring / project-specific changes)
- [ ] I'm uncertain — flagged in the PR description for author review

---

## Что сделано

Реализация E21.2 — четыре метода structured-output рефлексии в `OllamaReflectionModel`:

1. **`prompts.py`** — новый модуль с prompt-шаблонами и message-builder функциями:
   - `build_reframing_messages()` — для генерации reframing-заметок
   - `build_pattern_messages()` — для обнаружения паттернов
   - `build_narrative_messages()` — для обновления нарратива
   - `build_health_messages()` — для оценки здоровья по Jahoda
   - Все system prompts включают JSON-схему через `model.model_json_schema()` (никогда не захардкожена)
   - `OllamaMessage` TypedDict вынесен сюда для переиспользования

2. **`ollama_reflection_model.py`** — реализация четырёх методов:
   - `generate_reframing_note()` → делегирует в `_call_with_retry` через `build_reframing_messages`
   - `detect_pattern()` → через `build_pattern_messages`
   - `propose_narrative_update()` → через `build_narrative_messages`
   - `assess_health_criterion()` → через `build_health_messages`

3. **Тесты** — заменены stub-тесты `TestNotImplementedMethods` на `TestReflectionMethods` с моками httpx, проверяющие корректную делегацию и парсинг ответов.

Closes #183

## Как воспроизвести (демонстрация)

**N/A** — внутренний адаптер без CLI/UI поверхности. Проверка контракта:

```bash
python -c "
from atman.adapters.reflection.ollama_reflection_model import OllamaReflectionModel
from atman.core.ports.reflection import ReflectionModel
assert issubclass(OllamaReflectionModel, ReflectionModel)
print('Port contract OK')
"
```

## Тип изменений

- [ ] Исправление ошибки
- [x] Новая возможность / документация
- [ ] Рефакторинг (без смены поведения)
- [ ] Прочее:

## Карта системы

- **Затронутые разделы карты:** N/A — `OllamaReflectionModel` уже зарегистрирован в карте после E21.1; новый файл `prompts.py` — внутренний модуль адаптера, не меняет публичные порты/сервисы/CLI.
- **Покрытие тестами:** `tests/test_ollama_reflection_model.py::TestReflectionMethods`
- **Закрытые GAP'ы из §4.5:** N/A
- **Карта обновлена:** N/A — новые публичные модули/порты/адаптеры не добавлены

## Тесты-страховки агентной разработки

- N/A — изменения не затрагивают порты StateStore, сериализацию моделей, CLI-команды или lifecycle.

## Чеклист

- [x] Описание соответствует фактическим изменениям
- [x] При необходимости обновлены `README` / `docs` / демо-сценарий — N/A, внутренний адаптер
- [x] При необходимости обновлены `docs/architecture/SYSTEM_MAP.md` и `SYSTEM_MAP-ru.md` — N/A, внутренний модуль адаптера
- [x] `ruff check src/ tests/` — 0 ошибок
- [x] `ruff format --check src/ tests/` — 0 ошибок
- [x] `pyright src/ tests/` — 0 ошибок
- [x] `bandit -c pyproject.toml -r src/atman/` — 0 ошибок
- [x] `pytest tests/ -v --cov=atman --cov-fail-under=90` — 612 passed, coverage 92.73%
- [ ] GitHub Actions CI зелёный или локальные проверки выше объясняют, почему CI не применим

## Примечания

- Зависит от E21.1 (#182) — уже замержен
- `e2e/llm.py` pyright ошибка (`anthropic` not resolved) — pre-existing на `main`, не регрессия

Link to Devin session: https://app.devin.ai/sessions/57fbcc2e8d7344b4b769bb4eba70bc3e
Requested by: @hleserg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hleserg/atman/pull/384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->