### PR TITLE
[E24.1] FactStatus and fact validity fields in FactRecord and both adapters

### DIFF
--- a/src/atman/adapters/memory/file_backend.py
+++ b/src/atman/adapters/memory/file_backend.py
@@ -12,10 +12,12 @@ import tempfile
 import warnings
 from collections.abc import Iterator
 from contextlib import contextmanager
+from datetime import UTC, datetime
 from pathlib import Path
 from uuid import UUID
 
 from atman.core.models import FactRecord, Relation
+from atman.core.models.fact import FactStatus
 from atman.core.ports import FactualMemory
 
 
@@ -131,7 +133,12 @@ class FileBackend(FactualMemory):
         return fact.model_copy(deep=True) if fact else None
 
     def search(
-        self, query: str | None = None, tags: list[str] | None = None, limit: int = 10
+        self,
+        query: str | None = None,
+        tags: list[str] | None = None,
+        limit: int = 10,
+        *,
+        include_invalidated: bool = False,
     ) -> list[FactRecord]:
         """Ищет факты по запросу и тегам."""
         results = []
@@ -140,6 +147,9 @@ class FileBackend(FactualMemory):
         normalized_tags = [t.lower() for t in tags] if tags else None
 
         for fact in self._facts.values():
+            if not include_invalidated and fact.status != FactStatus.ACTIVE:
+                continue
+
             if normalized_query and normalized_query not in fact.content.lower():
                 continue
 
@@ -181,6 +191,59 @@ class FileBackend(FactualMemory):
         sorted_facts = sorted(self._facts.values(), key=lambda f: f.created_at, reverse=True)
 
         return [f.model_copy(deep=True) for f in sorted_facts[:limit]]
+
+    def invalidate_fact(
+        self,
+        fact_id: UUID,
+        *,
+        status: FactStatus,
+        note: str,
+        superseded_by: UUID | None = None,
+    ) -> FactRecord | None:
+        """Invalidates a fact by setting its status and metadata."""
+        with self._storage_lock():
+            updated_facts = self._read_facts_from_disk()
+            fact = updated_facts.get(fact_id)
+            if fact is None:
+                self._facts = updated_facts
+                return None
+
+            now = datetime.now(UTC)
+            fact.status = status
+            fact.invalidation_note = note
+            fact.invalidated_at = now
+            fact.superseded_by = superseded_by
+
+            if superseded_by is not None:
+                new_fact = updated_facts.get(superseded_by)
+                if new_fact is not None:
+                    fact.relations.append(
+                        Relation(target_id=superseded_by, relation_type="superseded_by")
+                    )
+                    new_fact.relations.append(
+                        Relation(target_id=fact_id, relation_type="supersedes")
+                    )
+
+            self._save_facts(updated_facts)
+            self._facts = updated_facts
+
+        return fact.model_copy(deep=True)
+
+    def list_invalidated(self, since: datetime | None = None) -> list[FactRecord]:
+        """Returns all invalidated (non-ACTIVE) facts."""
+        results = [
+            fact
+            for fact in self._facts.values()
+            if fact.status != FactStatus.ACTIVE
+            and (
+                since is None or (fact.invalidated_at is not None and fact.invalidated_at >= since)
+            )
+        ]
+        results.sort(
+            key=lambda f: f.invalidated_at if f.invalidated_at is not None else datetime.min,
+            reverse=True,
+        )
+        return [f.model_copy(deep=True) for f in results]
 
     def count(self) -> int:
         """Возвращает количество фактов."""

--- a/src/atman/adapters/memory/in_memory_backend.py
+++ b/src/atman/adapters/memory/in_memory_backend.py
@@ -5,9 +5,11 @@ In-memory адаптер для Factual Memory.
 Все данные хранятся в памяти и теряются при завершении процесса.
 """
 
+from datetime import UTC, datetime
 from uuid import UUID
 
 from atman.core.models import FactRecord, Relation
+from atman.core.models.fact import FactStatus
 from atman.core.ports import FactualMemory
 
 
@@ -34,7 +36,12 @@ class InMemoryBackend(FactualMemory):
         return fact.model_copy(deep=True) if fact else None
 
     def search(
-        self, query: str | None = None, tags: list[str] | None = None, limit: int = 10
+        self,
+        query: str | None = None,
+        tags: list[str] | None = None,
+        limit: int = 10,
+        *,
+        include_invalidated: bool = False,
     ) -> list[FactRecord]:
         """
         Ищет факты по запросу и тегам.
@@ -48,11 +55,12 @@ class InMemoryBackend(FactualMemory):
         normalized_tags = [t.lower() for t in tags] if tags else None
 
         for fact in self._facts.values():
-            # Проверка совпадения по запросу
+            if not include_invalidated and fact.status != FactStatus.ACTIVE:
+                continue
+
             if normalized_query and normalized_query not in fact.content.lower():
                 continue
 
-            # Проверка совпадения по тегам
             if normalized_tags:
                 fact_tags_lower = [t.lower() for t in fact.tags]
                 if not all(tag in fact_tags_lower for tag in normalized_tags):
@@ -87,6 +95,51 @@ class InMemoryBackend(FactualMemory):
     def clear(self) -> None:
         """Очищает все факты из памяти. Полезно для тестов."""
         self._facts.clear()
+
+    def invalidate_fact(
+        self,
+        fact_id: UUID,
+        *,
+        status: FactStatus,
+        note: str,
+        superseded_by: UUID | None = None,
+    ) -> FactRecord | None:
+        """Invalidates a fact by setting its status and metadata."""
+        fact = self._facts.get(fact_id)
+        if fact is None:
+            return None
+
+        now = datetime.now(UTC)
+        fact.status = status
+        fact.invalidation_note = note
+        fact.invalidated_at = now
+        fact.superseded_by = superseded_by
+
+        if superseded_by is not None:
+            new_fact = self._facts.get(superseded_by)
+            if new_fact is not None:
+                fact.relations.append(
+                    Relation(target_id=superseded_by, relation_type="superseded_by")
+                )
+                new_fact.relations.append(Relation(target_id=fact_id, relation_type="supersedes"))
+
+        return fact.model_copy(deep=True)
+
+    def list_invalidated(self, since: datetime | None = None) -> list[FactRecord]:
+        """Returns all invalidated (non-ACTIVE) facts."""
+        results = [
+            fact
+            for fact in self._facts.values()
+            if fact.status != FactStatus.ACTIVE
+            and (
+                since is None or (fact.invalidated_at is not None and fact.invalidated_at >= since)
+            )
+        ]
+        results.sort(
+            key=lambda f: f.invalidated_at if f.invalidated_at is not None else datetime.min,
+            reverse=True,
+        )
+        return [f.model_copy(deep=True) for f in results]
 
     def count(self) -> int:
         """Возвращает количество фактов в памяти."""

--- a/src/atman/core/models/__init__.py
+++ b/src/atman/core/models/__init__.py
@@ -12,7 +12,7 @@ from atman.core.models.experience import (
     ReframingNoteAppendResult,
     SessionExperience,
 )
-from atman.core.models.fact import FactRecord, Relation
+from atman.core.models.fact import FactRecord, FactStatus, Relation
 from atman.core.models.governance import GovernanceDecision, GovernanceMode
 from atman.core.models.identity import (
     CoreValue,
@@ -65,6 +65,7 @@ __all__ = [
     "EmotionalDepth",
     "ExperienceRecord",
     "FactRecord",
+    "FactStatus",
     "FeltSense",
     "Goal",
     "GoalHorizon",

--- a/src/atman/core/models/fact.py
+++ b/src/atman/core/models/fact.py
@@ -6,10 +6,20 @@
 """
 
 from datetime import UTC, datetime
+from enum import StrEnum
 from typing import Any
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class FactStatus(StrEnum):
+    """Validity status of a fact."""
+
+    ACTIVE = "active"
+    OUTDATED = "outdated"
+    RETRACTED = "retracted"
+    UNCERTAIN = "uncertain"
 
 
 class FactRecord(BaseModel):
@@ -27,6 +37,14 @@ class FactRecord(BaseModel):
     relations: list["Relation"] = Field(default_factory=list, description="Связи с другими фактами")
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     metadata: dict[str, Any] = Field(default_factory=dict, description="Дополнительные метаданные")
+    status: FactStatus = Field(default=FactStatus.ACTIVE, description="Validity status of the fact")
+    superseded_by: UUID | None = Field(
+        default=None, description="ID of the fact that supersedes this one"
+    )
+    invalidated_at: datetime | None = Field(
+        default=None, description="When this fact was invalidated"
+    )
+    invalidation_note: str = Field(default="", description="Reason or context for invalidation")
 
     @field_validator("content", "source")
     @classmethod

--- a/src/atman/core/ports/memory_backend.py
+++ b/src/atman/core/ports/memory_backend.py
@@ -5,9 +5,11 @@
 """
 
 from abc import ABC, abstractmethod
+from datetime import datetime
 from uuid import UUID
 
 from atman.core.models import FactRecord
+from atman.core.models.fact import FactStatus
 
 
 class FactualMemory(ABC):
@@ -50,7 +52,12 @@ class FactualMemory(ABC):
 
     @abstractmethod
     def search(
-        self, query: str | None = None, tags: list[str] | None = None, limit: int = 10
+        self,
+        query: str | None = None,
+        tags: list[str] | None = None,
+        limit: int = 10,
+        *,
+        include_invalidated: bool = False,
     ) -> list[FactRecord]:
         """
         Ищет факты по текстовому запросу и/или тегам.
@@ -59,6 +66,7 @@ class FactualMemory(ABC):
             query: Текстовый запрос для поиска в content
             tags: Список тегов для фильтрации
             limit: Максимальное количество результатов
+            include_invalidated: Включить недействительные факты в результаты
 
         Returns:
             list[FactRecord]: Список найденных фактов
@@ -90,5 +98,45 @@ class FactualMemory(ABC):
 
         Returns:
             list[FactRecord]: Список фактов, отсортированных по created_at (новые первыми)
+        """
+        pass
+
+    @abstractmethod
+    def invalidate_fact(
+        self,
+        fact_id: UUID,
+        *,
+        status: FactStatus,
+        note: str,
+        superseded_by: UUID | None = None,
+    ) -> FactRecord | None:
+        """
+        Invalidates a fact by setting its status and metadata.
+
+        If ``superseded_by`` is provided, creates bidirectional relations:
+        - ``"superseded_by"`` on the invalidated fact pointing to the new fact
+        - ``"supersedes"`` on the new fact pointing to the invalidated fact
+
+        Args:
+            fact_id: ID of the fact to invalidate
+            status: New validity status (must not be ACTIVE)
+            note: Reason or context for invalidation
+            superseded_by: Optional ID of the replacement fact
+
+        Returns:
+            Updated FactRecord or None if fact_id not found
+        """
+        pass
+
+    @abstractmethod
+    def list_invalidated(self, since: datetime | None = None) -> list[FactRecord]:
+        """
+        Returns all invalidated (non-ACTIVE) facts.
+
+        Args:
+            since: If given, only return facts invalidated at or after this time
+
+        Returns:
+            list[FactRecord]: Invalidated facts sorted by invalidated_at desc
         """
         pass

--- a/tests/test_file_backend.py
+++ b/tests/test_file_backend.py
@@ -8,7 +8,7 @@ from tempfile import NamedTemporaryFile
 import pytest
 
 from atman.adapters.memory import FileBackend
-from atman.core.models import FactRecord
+from atman.core.models import FactRecord, FactStatus
 
 
 @pytest.fixture
@@ -287,3 +287,116 @@ def test_add_fact_duplicate_id_raises_with_clear_message(temp_file, backend):
 
     with pytest.raises(ValueError, match=str(fact.id)):
         backend.add_fact(fact)
+
+
+# --- E24.1: FactStatus, invalidation, search filtering ---
+
+
+def test_search_excludes_invalidated_by_default(backend):
+    """E24.1 AC-3: search() returns only ACTIVE facts when invalidated facts exist."""
+    active = backend.add_fact(FactRecord(content="Active fact", source="test"))
+    outdated = backend.add_fact(FactRecord(content="Outdated fact", source="test"))
+    backend.invalidate_fact(outdated.id, status=FactStatus.OUTDATED, note="old")
+
+    results = backend.search()
+    assert len(results) == 1
+    assert results[0].id == active.id
+
+
+def test_search_includes_invalidated_when_requested(backend):
+    """E24.1 AC-4: search(include_invalidated=True) returns all facts including OUTDATED."""
+    backend.add_fact(FactRecord(content="Active fact", source="test"))
+    outdated = backend.add_fact(FactRecord(content="Outdated fact", source="test"))
+    backend.invalidate_fact(outdated.id, status=FactStatus.OUTDATED, note="old")
+
+    results = backend.search(include_invalidated=True)
+    assert len(results) == 2
+
+
+def test_invalidate_fact_creates_bidirectional_relations(backend):
+    """E24.1 AC-5: invalidate_fact with superseded_by creates relations on both facts."""
+    old_fact = backend.add_fact(FactRecord(content="Old fact", source="test"))
+    new_fact = backend.add_fact(FactRecord(content="New fact", source="test"))
+
+    result = backend.invalidate_fact(
+        old_fact.id,
+        status=FactStatus.OUTDATED,
+        note="replaced",
+        superseded_by=new_fact.id,
+    )
+
+    assert result is not None
+    assert result.status == FactStatus.OUTDATED
+    assert result.superseded_by == new_fact.id
+    assert result.invalidation_note == "replaced"
+    assert result.invalidated_at is not None
+
+    retrieved_old = backend.get_fact(old_fact.id)
+    assert retrieved_old is not None
+    superseded_by_rels = [r for r in retrieved_old.relations if r.relation_type == "superseded_by"]
+    assert len(superseded_by_rels) == 1
+    assert superseded_by_rels[0].target_id == new_fact.id
+
+    retrieved_new = backend.get_fact(new_fact.id)
+    assert retrieved_new is not None
+    supersedes_rels = [r for r in retrieved_new.relations if r.relation_type == "supersedes"]
+    assert len(supersedes_rels) == 1
+    assert supersedes_rels[0].target_id == old_fact.id
+
+
+def test_invalidate_fact_nonexistent_returns_none(backend):
+    """E24.1: invalidate_fact returns None for unknown fact_id."""
+    from uuid import uuid4
+
+    result = backend.invalidate_fact(uuid4(), status=FactStatus.RETRACTED, note="n/a")
+    assert result is None
+
+
+def test_invalidate_fact_persistence(temp_file):
+    """E24.1: invalidation state persists across FileBackend instances."""
+    backend1 = FileBackend(temp_file)
+    fact = backend1.add_fact(FactRecord(content="Persistent invalidation", source="test"))
+    new_fact = backend1.add_fact(FactRecord(content="Replacement", source="test"))
+    backend1.invalidate_fact(
+        fact.id,
+        status=FactStatus.OUTDATED,
+        note="persisted",
+        superseded_by=new_fact.id,
+    )
+
+    backend2 = FileBackend(temp_file)
+    retrieved = backend2.get_fact(fact.id)
+    assert retrieved is not None
+    assert retrieved.status == FactStatus.OUTDATED
+    assert retrieved.invalidation_note == "persisted"
+    assert retrieved.superseded_by == new_fact.id
+    assert retrieved.invalidated_at is not None
+
+    superseded_by_rels = [r for r in retrieved.relations if r.relation_type == "superseded_by"]
+    assert len(superseded_by_rels) == 1
+
+
+def test_list_invalidated(backend):
+    """E24.1: list_invalidated returns non-ACTIVE facts sorted by invalidated_at desc."""
+    f1 = backend.add_fact(FactRecord(content="Fact 1", source="test"))
+    f2 = backend.add_fact(FactRecord(content="Fact 2", source="test"))
+    backend.add_fact(FactRecord(content="Active fact", source="test"))
+
+    backend.invalidate_fact(f1.id, status=FactStatus.OUTDATED, note="old")
+    backend.invalidate_fact(f2.id, status=FactStatus.RETRACTED, note="wrong")
+
+    invalidated = backend.list_invalidated()
+    assert len(invalidated) == 2
+    assert invalidated[0].id == f2.id
+    assert invalidated[1].id == f1.id
+
+
+def test_invalidate_lifecycle(backend):
+    """E24.1: full lifecycle — add, invalidate, search, list_invalidated."""
+    fact = backend.add_fact(FactRecord(content="Lifecycle test", source="test"))
+    assert len(backend.search(query="lifecycle")) == 1
+
+    backend.invalidate_fact(fact.id, status=FactStatus.OUTDATED, note="done")
+    assert len(backend.search(query="lifecycle")) == 0
+    assert len(backend.search(query="lifecycle", include_invalidated=True)) == 1
+    assert len(backend.list_invalidated()) == 1

--- a/tests/test_in_memory_backend.py
+++ b/tests/test_in_memory_backend.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 import pytest
 
 from atman.adapters.memory import InMemoryBackend
-from atman.core.models import FactRecord
+from atman.core.models import FactRecord, FactStatus
 
 
 @pytest.fixture
@@ -157,3 +157,127 @@ def test_clear(backend):
 
     backend.clear()
     assert backend.count() == 0
+
+
+# --- E24.1: FactStatus, invalidation, search filtering ---
+
+
+def test_search_excludes_invalidated_by_default(backend):
+    """E24.1 AC-3: search() with no args returns only ACTIVE facts."""
+    active = backend.add_fact(FactRecord(content="Active fact", source="test"))
+    outdated = backend.add_fact(FactRecord(content="Outdated fact", source="test"))
+    backend.invalidate_fact(outdated.id, status=FactStatus.OUTDATED, note="old")
+
+    results = backend.search()
+    assert len(results) == 1
+    assert results[0].id == active.id
+
+
+def test_search_includes_invalidated_when_requested(backend):
+    """E24.1 AC-4: search(include_invalidated=True) returns all facts."""
+    backend.add_fact(FactRecord(content="Active fact", source="test"))
+    outdated = backend.add_fact(FactRecord(content="Outdated fact", source="test"))
+    backend.invalidate_fact(outdated.id, status=FactStatus.OUTDATED, note="old")
+
+    results = backend.search(include_invalidated=True)
+    assert len(results) == 2
+
+
+def test_invalidate_fact_creates_bidirectional_relations(backend):
+    """E24.1 AC-5: invalidate_fact creates superseded_by/supersedes relations."""
+    old_fact = backend.add_fact(FactRecord(content="Old fact", source="test"))
+    new_fact = backend.add_fact(FactRecord(content="New fact", source="test"))
+
+    result = backend.invalidate_fact(
+        old_fact.id,
+        status=FactStatus.OUTDATED,
+        note="replaced by new",
+        superseded_by=new_fact.id,
+    )
+
+    assert result is not None
+    assert result.status == FactStatus.OUTDATED
+    assert result.superseded_by == new_fact.id
+    assert result.invalidation_note == "replaced by new"
+    assert result.invalidated_at is not None
+
+    retrieved_old = backend.get_fact(old_fact.id)
+    assert retrieved_old is not None
+    superseded_by_rels = [r for r in retrieved_old.relations if r.relation_type == "superseded_by"]
+    assert len(superseded_by_rels) == 1
+    assert superseded_by_rels[0].target_id == new_fact.id
+
+    retrieved_new = backend.get_fact(new_fact.id)
+    assert retrieved_new is not None
+    supersedes_rels = [r for r in retrieved_new.relations if r.relation_type == "supersedes"]
+    assert len(supersedes_rels) == 1
+    assert supersedes_rels[0].target_id == old_fact.id
+
+
+def test_invalidate_fact_nonexistent_returns_none(backend):
+    """E24.1: invalidate_fact returns None for unknown fact_id."""
+    result = backend.invalidate_fact(uuid4(), status=FactStatus.RETRACTED, note="n/a")
+    assert result is None
+
+
+def test_invalidate_fact_without_superseded_by(backend):
+    """E24.1: invalidation without superseded_by sets status fields only."""
+    fact = backend.add_fact(FactRecord(content="Uncertain fact", source="test"))
+    result = backend.invalidate_fact(fact.id, status=FactStatus.UNCERTAIN, note="doubted")
+
+    assert result is not None
+    assert result.status == FactStatus.UNCERTAIN
+    assert result.superseded_by is None
+    assert result.invalidation_note == "doubted"
+    assert result.invalidated_at is not None
+
+    retrieved = backend.get_fact(fact.id)
+    assert retrieved is not None
+    assert len([r for r in retrieved.relations if r.relation_type == "superseded_by"]) == 0
+
+
+def test_list_invalidated(backend):
+    """E24.1: list_invalidated returns only non-ACTIVE facts sorted by invalidated_at desc."""
+    f1 = backend.add_fact(FactRecord(content="Fact 1", source="test"))
+    f2 = backend.add_fact(FactRecord(content="Fact 2", source="test"))
+    backend.add_fact(FactRecord(content="Active fact", source="test"))
+
+    backend.invalidate_fact(f1.id, status=FactStatus.OUTDATED, note="old")
+    backend.invalidate_fact(f2.id, status=FactStatus.RETRACTED, note="wrong")
+
+    invalidated = backend.list_invalidated()
+    assert len(invalidated) == 2
+    assert invalidated[0].id == f2.id
+    assert invalidated[1].id == f1.id
+
+
+def test_list_invalidated_with_since_filter(backend):
+    """E24.1: list_invalidated with since filter."""
+    from datetime import UTC, datetime
+
+    f1 = backend.add_fact(FactRecord(content="Old invalidated", source="test"))
+    backend.invalidate_fact(f1.id, status=FactStatus.OUTDATED, note="old")
+
+    f2 = backend.add_fact(FactRecord(content="New invalidated", source="test"))
+    backend.invalidate_fact(f2.id, status=FactStatus.RETRACTED, note="new")
+
+    all_invalidated = backend.list_invalidated()
+    assert len(all_invalidated) == 2
+
+    earliest = min(f.invalidated_at for f in all_invalidated if f.invalidated_at is not None)
+    filtered = backend.list_invalidated(since=earliest)
+    assert len(filtered) >= 1
+
+    future = datetime(2099, 1, 1, tzinfo=UTC)
+    assert len(backend.list_invalidated(since=future)) == 0
+
+
+def test_invalidate_lifecycle(backend):
+    """E24.1: full lifecycle — add, invalidate, search, list_invalidated."""
+    fact = backend.add_fact(FactRecord(content="Lifecycle test", source="test"))
+    assert len(backend.search(query="lifecycle")) == 1
+
+    backend.invalidate_fact(fact.id, status=FactStatus.OUTDATED, note="done")
+    assert len(backend.search(query="lifecycle")) == 0
+    assert len(backend.search(query="lifecycle", include_invalidated=True)) == 1
+    assert len(backend.list_invalidated()) == 1

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 import pytest
 
-from atman.core.models import FactRecord, Relation
+from atman.core.models import FactRecord, FactStatus, Relation
 
 
 def test_fact_record_creation():
@@ -130,3 +130,52 @@ def test_fact_record_with_unicode_and_emoji_content():
     fact = FactRecord(content=text, source="unicode-test")
     reloaded = FactRecord.model_validate_json(fact.model_dump_json())
     assert reloaded.content == text
+
+
+# --- E24.1: FactStatus and fact validity fields ---
+
+
+def test_fact_status_enum_values():
+    """E24.1 AC-1: FactStatus has expected string values."""
+    assert FactStatus.ACTIVE == "active"
+    assert FactStatus.OUTDATED == "outdated"
+    assert FactStatus.RETRACTED == "retracted"
+    assert FactStatus.UNCERTAIN == "uncertain"
+
+
+def test_fact_record_default_status_is_active():
+    """E24.1 AC-2: FactRecord defaults to ACTIVE status."""
+    fact = FactRecord.model_validate({"content": "x", "source": "y"})
+    assert fact.status == FactStatus.ACTIVE
+    assert fact.superseded_by is None
+    assert fact.invalidated_at is None
+    assert fact.invalidation_note == ""
+
+
+def test_fact_record_status_roundtrip():
+    """E24.1: FactStatus round-trips through JSON serialization."""
+    fact = FactRecord(
+        content="Old fact",
+        source="test",
+        status=FactStatus.OUTDATED,
+        invalidation_note="replaced",
+        superseded_by=uuid4(),
+    )
+    json_data = fact.model_dump_json()
+    restored = FactRecord.model_validate_json(json_data)
+    assert restored.status == FactStatus.OUTDATED
+    assert restored.invalidation_note == "replaced"
+    assert restored.superseded_by == fact.superseded_by
+
+
+def test_fact_record_invalidated_at_field():
+    """E24.1: invalidated_at field can be set and round-trips."""
+    now = datetime.now()
+    fact = FactRecord(
+        content="Fact",
+        source="test",
+        status=FactStatus.RETRACTED,
+        invalidated_at=now,
+    )
+    restored = FactRecord.model_validate_json(fact.model_dump_json())
+    assert restored.invalidated_at is not None


### PR DESCRIPTION
## PLAYBOOK markers

- [x] I introduced no generalizable patterns (pure refactoring / project-specific changes)

---

## Что сделано

Реализация подзадачи E24.1 из эпика #373: добавлен `FactStatus(StrEnum)` и четыре поля валидности факта в `FactRecord`, реализованы `invalidate_fact()` и `list_invalidated()` в обоих адаптерах, `search()` по умолчанию исключает недействительные факты.

**Изменённые файлы:**
- `src/atman/core/models/fact.py` — добавлен `FactStatus(StrEnum)` с значениями `active`, `outdated`, `retracted`, `uncertain`; четыре новых поля на `FactRecord` с дефолтами (обратная совместимость)
- `src/atman/core/models/__init__.py` — экспорт `FactStatus`
- `src/atman/core/ports/memory_backend.py` — абстрактные методы `invalidate_fact()`, `list_invalidated()`; параметр `include_invalidated: bool = False` в `search()`
- `src/atman/adapters/memory/in_memory_backend.py` — реализация обоих новых методов; фильтрация в `search()`
- `src/atman/adapters/memory/file_backend.py` — реализация обоих новых методов внутри `_storage_lock()` с прямым append `Relation` (без рекурсивного `self.link()` во избежание deadlock); фильтрация в `search()`

## Как воспроизвести (демонстрация)

**N/A** — данная подзадача не добавляет CLI-команд или пользовательского поведения (это E24.10).

- **Команда(ы):**
```bash
pytest tests/test_models.py tests/test_file_backend.py tests/test_in_memory_backend.py -v -k "status or invalidat or lifecycle" --tb=short -q
```
- **Ожидаемый результат:** 19 тестов проходят

## Тип изменений

- [x] Новая возможность / документация

## Карта системы

- **Затронутые разделы карты:** N/A — новые публичные методы добавлены к существующим портам/адаптерам, структура модулей не изменена
- **Покрытие тестами:**
  - `tests/test_models.py::test_fact_status_*`, `test_fact_record_default_status_*`, `test_fact_record_status_roundtrip`, `test_fact_record_invalidated_at_field`
  - `tests/test_in_memory_backend.py::test_search_excludes_invalidated_*`, `test_invalidate_fact_*`, `test_list_invalidated*`, `test_invalidate_lifecycle`
  - `tests/test_file_backend.py::test_search_excludes_invalidated_*`, `test_invalidate_fact_*`, `test_list_invalidated`, `test_invalidate_lifecycle`
- **Закрытые GAP'ы из §4.5:** N/A
- **Карта обновлена:** N/A — не добавляет/удаляет/переименовывает модули, порты или адаптеры

## Тесты-страховки агентной разработки

- N/A — `test_state_store_contract.py`: порт `StateStore` не затронут
- N/A — `test_serialization_roundtrip.py`, `test_golden_schema.py`: эти файлы ещё не существуют в проекте; roundtrip покрыт в `test_models.py::test_fact_record_status_roundtrip`
- N/A — остальные: CLI, storage path, domain invariants, lifecycle — не затронуты

## Чеклист

- [x] Описание соответствует фактическим изменениям
- [x] При необходимости обновлены `README` / `docs` / демо-сценарий — N/A, нет пользовательских изменений
- [x] При необходимости обновлены `docs/architecture/SYSTEM_MAP.md` и `SYSTEM_MAP-ru.md` — N/A, структура модулей не изменена
- [x] `ruff check src/ tests/` — 0 ошибок
- [x] `ruff format --check src/ tests/` — 0 ошибок
- [x] `pyright src/ tests/` — 0 новых ошибок (1 pre-existing `e2e/llm.py` anthropic import)
- [x] `bandit -c pyproject.toml -r src/atman/` — 0 ошибок
- [x] `pytest tests/ -v --cov=atman --cov-fail-under=90` — 631 тест, покрытие 93.44%
- [ ] GitHub Actions CI зелёный

## Примечания

- Все новые поля имеют дефолтные значения — полная обратная совместимость с существующими данными
- `FileBackend.invalidate_fact()` не вызывает `self.link()` внутри `_storage_lock()` — вместо этого напрямую создаёт `Relation` объекты и добавляет их к обоим фактам, затем вызывает `_save_facts()`, как указано в issue
- Закрывает #374

Link to Devin session: https://app.devin.ai/sessions/5c5e10a765514bc0804d1346d037d171
Requested by: @hleserg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hleserg/atman/pull/385" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->