### PR TITLE
eval: add production/eval boundary infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,9 @@ htmlcov/
 
 # Atman
 .atman/
+# Eval subsystem — local-only artifacts
+eval/data/
+eval/external/
+.issues_state.json
+requirements-prod.txt
+requirements-eval.txt

--- a/.importlinter
+++ b/.importlinter
@@ -1,0 +1,23 @@
+[importlinter]
+root_packages =
+    atman
+
+# Forbid production modules from importing atman.eval
+[importlinter:contract:eval-isolation]
+name = Production code must not import atman.eval
+type = forbidden
+source_modules =
+    atman.factual_memory
+    atman.experience_store
+    atman.reflection_engine
+    atman.identity_store
+    atman.skill_loop
+    atman.session_manager
+    atman.reality_anchor
+    atman.proactive_engine
+    atman.affective_regulation
+forbidden_modules =
+    atman.eval
+ignore_imports =
+    # No exceptions allowed — review this list carefully if you add one.
+

--- a/Makefile
+++ b/Makefile
@@ -123,3 +123,31 @@ playbook-check:
 
 playbook-audit:
 	python3 scripts/suggest_playbook.py
+
+# ===== Eval / Production isolation =====
+# (added by setup_prod_eval_boundary.sh — see docs/architecture/PROD_EVAL_BOUNDARY.md)
+
+.PHONY: lint-boundary verify-prod-isolation eval-db-init eval-db-migrate eval-db-downgrade eval-up eval-down
+
+lint-boundary:
+	lint-imports
+
+verify-prod-isolation:
+	bash scripts/infra/verify_prod_isolation.sh
+
+eval-db-init:
+	alembic -c eval/migrations/alembic.ini upgrade head
+
+eval-db-migrate:
+	alembic -c eval/migrations/alembic.ini revision -m "$(MSG)"
+
+eval-db-downgrade:
+	alembic -c eval/migrations/alembic.ini downgrade -1
+
+COMPOSE_EVAL = docker compose -f docker-compose.yml -f docker-compose.eval.yml
+
+eval-up:
+	$(COMPOSE_EVAL) up -d
+
+eval-down:
+	$(COMPOSE_EVAL) down

--- a/docker-compose.eval.yml
+++ b/docker-compose.eval.yml
@@ -1,0 +1,14 @@
+# Eval-only Docker services.
+# Overlays on docker-compose.yml — production never includes this file.
+#
+# Apply with:
+#   docker compose -f docker-compose.yml -f docker-compose.eval.yml up -d
+# or:
+#   make eval-up
+
+services: {}
+# Future eval-only services may go here, e.g.:
+#   - dedicated qdrant instance for eval indexes
+#   - jupyter notebook for analysis
+#   - streamlit dashboard container
+

--- a/docs/architecture/PROD_EVAL_BOUNDARY.md
+++ b/docs/architecture/PROD_EVAL_BOUNDARY.md
@@ -1,0 +1,177 @@
+# Production / Eval Boundary
+
+This document describes the architectural contract that keeps Atman's evaluation
+subsystem isolated from production code, and how to maintain that contract as
+the project evolves.
+
+## Why this boundary exists
+
+Atman is a library that other people will install and run. Production users
+should pay zero cost for the evaluation infrastructure that benchmarks the
+project. Streamlit dashboards, HuggingFace datasets, OpenAI fallback judges,
+benchmark harnesses, GPU CI glue — none of it belongs in the runtime an agent
+ships with.
+
+But eval also can't be a separate repo: it is too tightly coupled to the
+production schema, identity model, and APIs to live elsewhere without
+duplicating types and slowing down iteration.
+
+The compromise: **one repo, two install profiles**.
+
+## The contract
+
+### Install profiles
+
+| Profile      | Command                       | What you get                            |
+|--------------|-------------------------------|-----------------------------------------|
+| Production   | `pip install atman`           | Core runtime: ~10 deps                  |
+| Eval         | `pip install "atman[eval]"`   | Core + ~15 eval-only deps               |
+| Dev          | `pip install "atman[dev]"`    | Core + dev tooling                      |
+| Everything   | `pip install "atman[all]"`    | Core + eval + dev                       |
+
+### Module layout
+
+```
+src/atman/
+├── factual_memory/          # production
+├── experience_store/        # production
+├── reflection_engine/       # production
+├── identity_store/          # production
+├── skill_loop/              # production
+├── session_manager/         # production
+├── reality_anchor/          # production
+├── proactive_engine/        # production
+├── affective_regulation/    # production
+└── eval/                    # NOT production — guarded by lazy import
+    ├── __init__.py          # imports _deps_check; raises ImportError without [eval]
+    ├── _deps_check.py
+    ├── runner/              # filled by epic E1
+    ├── judge/               # filled by epic E2
+    ├── benchmarks/          # filled by epics E5-E20
+    └── dashboard/           # filled by epic E4
+```
+
+### Migration trees
+
+```
+migrations/                  # main app schema
+└── versions/
+
+eval/migrations/             # eval.* schema only
+├── alembic.ini
+├── env.py
+└── versions/                # filled by epic E0
+```
+
+Apply main migrations: `alembic upgrade head`
+Apply eval migrations: `make eval-db-init`
+
+These are independent. `alembic_version` and `alembic_version_eval` tables coexist.
+
+### Docker
+
+```
+docker-compose.yml           # production services (postgres, qdrant, ollama)
+docker-compose.eval.yml      # eval-only services (currently empty placeholder)
+```
+
+Apply both: `make eval-up` (runs `docker compose -f docker-compose.yml -f docker-compose.eval.yml up -d`)
+
+### One-way dependency rule
+
+**Allowed:**
+- `atman.eval.benchmarks.g1` imports from `atman.identity_store` (eval reads prod)
+- `atman.eval.runner` imports from `atman.factual_memory` (eval uses prod)
+
+**Forbidden:**
+- `atman.factual_memory` imports from `atman.eval.judge` (prod uses eval) — **NO**
+- `atman.skill_loop` imports from `atman.eval.benchmarks` — **NO**
+
+Enforced by `import-linter` (configuration in `.importlinter`). CI runs
+`lint-imports` on every PR.
+
+## How to add a new module — decision tree
+
+```
+Is it needed at runtime by an agent talking to a user?
+├── YES → it's production
+│         place under src/atman/<name>/
+│         deps go in [project.dependencies]
+│         freely import from other prod modules
+│         do NOT import from atman.eval.*
+│
+└── NO  → it's eval
+          place under src/atman/eval/<name>/
+          deps go in [project.optional-dependencies] eval = [...]
+          may import from atman.* freely
+          will not be installed in production
+```
+
+Examples:
+- New benchmark? → `src/atman/eval/benchmarks/<name>.py`
+- New persona feature for live agents? → `src/atman/personas/`
+- Streamlit visualization? → `src/atman/eval/dashboard/`
+- Better embedding cache for production? → `src/atman/factual_memory/`
+
+## How to add a new dependency
+
+```
+Is the dep needed at runtime by an agent talking to a user?
+├── YES → [project.dependencies]
+│         (be careful — production deps stay forever)
+│
+└── NO  → [project.optional-dependencies] eval = [...]
+          (or `dev` for tooling)
+```
+
+After adding, regenerate the lock files:
+```bash
+pip install -e . && pip freeze > requirements-prod.txt
+pip install -e ".[eval]" && pip freeze > requirements-eval.txt
+```
+
+Commit both. CI uses these to detect accidental drift.
+
+## CI enforcement
+
+Every PR runs:
+1. `lint-imports` — verifies prod modules don't import `atman.eval`
+2. `make verify-prod-isolation` — installs `atman` in a clean venv, asserts
+   no eval deps got pulled, verifies `import atman.eval` fails
+
+Both must pass for merge.
+
+## Local verification
+
+```bash
+# Lint check (fast)
+make lint-boundary
+
+# Full verification (creates a clean venv, installs, checks)
+make verify-prod-isolation
+```
+
+## Known limitations
+
+1. **Lazy/dynamic imports bypass the linter.** If someone writes
+   `importlib.import_module("atman.eval.judge")` from a prod module, the
+   linter won't catch it. We accept this; reviewer judgment compensates.
+
+2. **Optional-deps don't prevent runtime imports if eval IS installed.**
+   If a user did `pip install "atman[eval]"` and then production code
+   imports from `atman.eval`, it works at runtime — only the linter catches
+   the violation. CI must be the gate.
+
+3. **A single repo can't isolate as strongly as two repos can.** If
+   absolute isolation becomes critical (e.g., security audit requires it),
+   a future "Variant B" migration to a separate `atman-eval` repo is
+   possible. For now, single-repo + linter is the pragmatic balance.
+
+## When to revisit
+
+- Eval grows past ~30% of the codebase by line count → consider splitting to separate repo.
+- Eval-deps create install-time conflicts with production deps → split.
+- Security/compliance demands cryptographic isolation → split.
+
+Until then, this boundary is the right tool.
+

--- a/eval/migrations/alembic.ini
+++ b/eval/migrations/alembic.ini
@@ -1,0 +1,45 @@
+# Alembic config for the eval schema only.
+# Main app migrations have their own alembic.ini at repo root.
+# Apply via: make eval-db-init
+
+[alembic]
+script_location = eval/migrations
+prepend_sys_path = .
+version_path_separator = os
+# Distinct version table avoids collision with main migrations
+# version_table is set in env.py to keep alembic.ini portable
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S
+

--- a/eval/migrations/env.py
+++ b/eval/migrations/env.py
@@ -1,0 +1,57 @@
+"""Alembic env.py for the eval schema migrations.
+
+Reads DB URL from EVAL_DB_URL or falls back to ATMAN_DB_URL.
+Uses a distinct version_table (alembic_version_eval) so it does not
+collide with main migrations.
+"""
+
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = None  # using raw SQL migrations, not autogenerate
+
+DB_URL = os.environ.get("EVAL_DB_URL") or os.environ.get(
+    "ATMAN_DB_URL", "postgresql+psycopg://atman@localhost:5432/atman"
+)
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=DB_URL,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        version_table="alembic_version_eval",
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    config_dict = config.get_section(config.config_ini_section, {})
+    config_dict["sqlalchemy.url"] = DB_URL
+    connectable = engine_from_config(
+        config_dict, prefix="sqlalchemy.", poolclass=pool.NullPool
+    )
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            version_table="alembic_version_eval",
+        )
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()
+

--- a/eval/migrations/script.py.mako
+++ b/eval/migrations/script.py.mako
@@ -1,0 +1,27 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}
+

--- a/scripts/infra/verify_prod_isolation.sh
+++ b/scripts/infra/verify_prod_isolation.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Verify that a bare-prod install does not pull eval dependencies
+# and that atman.eval is not importable.
+
+set -euo pipefail
+
+TMP=$(mktemp -d)
+trap "rm -rf $TMP" EXIT
+
+echo "→ Creating clean venv at $TMP/venv"
+python -m venv "$TMP/venv"
+# shellcheck source=/dev/null
+source "$TMP/venv/bin/activate"
+
+echo "→ Installing bare atman (no extras)"
+pip install -e . --quiet --upgrade pip > /dev/null
+pip install -e . --quiet
+
+# Forbidden packages in prod
+FORBIDDEN=(streamlit huggingface_hub datasets plotly openai)
+FAIL=0
+
+echo ""
+echo "→ Checking forbidden packages are NOT installed:"
+for pkg in "${FORBIDDEN[@]}"; do
+    if pip show "$pkg" > /dev/null 2>&1; then
+        echo "  ✗ $pkg should NOT be in prod"
+        FAIL=1
+    else
+        echo "  ✓ $pkg absent"
+    fi
+done
+
+echo ""
+echo "→ Checking atman imports:"
+if python -c "import atman" 2>/dev/null; then
+    echo "  ✓ import atman OK"
+else
+    echo "  ✗ import atman failed"
+    FAIL=1
+fi
+
+echo "→ Checking atman.eval is properly gated:"
+if python -c "import atman.eval" 2>/dev/null; then
+    echo "  ✗ atman.eval imported without [eval] extras — gate broken"
+    FAIL=1
+else
+    echo "  ✓ atman.eval correctly raises ImportError without [eval]"
+fi
+
+echo ""
+if [[ $FAIL -eq 0 ]]; then
+    echo "✅ Production isolation verified."
+    exit 0
+else
+    echo "❌ Production isolation BROKEN. See messages above."
+    exit 1
+fi
+

--- a/src/atman/eval/__init__.py
+++ b/src/atman/eval/__init__.py
@@ -1,0 +1,20 @@
+"""Atman evaluation subsystem.
+
+Optional namespace — not part of the production install.
+Install with: pip install 'atman[eval]'
+
+This module is intentionally isolated from the production code in
+src/atman/{factual_memory,identity_store,...}. Production code MUST NOT
+import from atman.eval; this is enforced by import-linter (.importlinter)
+and verified by `make verify-prod-isolation`.
+"""
+
+from atman.eval._deps_check import _check_eval_deps_installed
+
+_check_eval_deps_installed()
+
+# Public API is filled in by epics E1-E20:
+#   from atman.eval.runner import BenchmarkRunner, RunContext
+#   from atman.eval.judge import OllamaJudge, OpenAIJudge
+#   ...
+

--- a/src/atman/eval/_deps_check.py
+++ b/src/atman/eval/_deps_check.py
@@ -1,0 +1,32 @@
+"""Lazy dependency check for atman.eval.
+
+Imported once on `import atman.eval`. Raises a friendly ImportError if
+required eval dependencies are missing.
+"""
+
+import importlib.util
+
+# Canary deps — if any of these is missing, the user installed bare `atman`
+# instead of `atman[eval]`. We don't check every eval dep, just the obvious
+# ones; full dep set is in pyproject.toml.
+_REQUIRED_CANARIES = (
+    ("streamlit", "streamlit"),
+    ("huggingface_hub", "huggingface_hub"),
+    ("datasets", "datasets"),
+)
+
+
+def _check_eval_deps_installed() -> None:
+    missing = [
+        pip_name
+        for module_name, pip_name in _REQUIRED_CANARIES
+        if importlib.util.find_spec(module_name) is None
+    ]
+    if missing:
+        raise ImportError(
+            "atman.eval requires extra dependencies (currently missing: "
+            + ", ".join(missing)
+            + "). Install with:\n\n    pip install 'atman[eval]'\n\n"
+            "or with uv:\n\n    uv sync --extra eval\n"
+        )
+


### PR DESCRIPTION
Introduces architectural isolation between production runtime and evaluation subsystem. 

Key changes:
- .importlinter contract forbidding prod→eval imports
- Separate Alembic migration tree for eval schema
- Docker Compose for eval environment
- 
Production users installing  will not pull eval dependencies (streamlit, huggingface_hub, datasets, etc.). Eval code lives under  with separate install profile .