### PR TITLE
fix: support Python 3.11 (typing.override → typing_extensions)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,7 @@ include = ["src", "tests", "e2e"]
 exclude = ["src/atman/reflection/store.py"]
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py311"
 line-length = 100
 src = ["src", "tests", "e2e"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "atman"
 version = "0.1.0"
 description = "Психологический слой для AI-агента"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 readme = "README.md"
 
 dependencies = [

--- a/src/atman/adapters/memory/bm25_embedding.py
+++ b/src/atman/adapters/memory/bm25_embedding.py
@@ -9,6 +9,7 @@ import hashlib
 import math
 import re
 from collections import Counter
+
 from typing_extensions import override
 
 from atman.core.ports.embedding import EmbeddingPort

--- a/src/atman/adapters/memory/bm25_embedding.py
+++ b/src/atman/adapters/memory/bm25_embedding.py
@@ -9,7 +9,7 @@ import hashlib
 import math
 import re
 from collections import Counter
-from typing import override
+from typing_extensions import override
 
 from atman.core.ports.embedding import EmbeddingPort
 

--- a/src/atman/adapters/memory/in_memory_usage_log.py
+++ b/src/atman/adapters/memory/in_memory_usage_log.py
@@ -5,8 +5,9 @@ Simple in-memory storage for usage records.
 Not persistent - suitable for testing and short-lived sessions.
 """
 
-from typing_extensions import override
 from uuid import UUID
+
+from typing_extensions import override
 
 from atman.core.ports.memory_usage_log import MemoryUsageLog, MemoryUsageRecord
 

--- a/src/atman/adapters/memory/in_memory_usage_log.py
+++ b/src/atman/adapters/memory/in_memory_usage_log.py
@@ -5,7 +5,7 @@ Simple in-memory storage for usage records.
 Not persistent - suitable for testing and short-lived sessions.
 """
 
-from typing import override
+from typing_extensions import override
 from uuid import UUID
 
 from atman.core.ports.memory_usage_log import MemoryUsageLog, MemoryUsageRecord

--- a/src/atman/adapters/memory/mock_embedding.py
+++ b/src/atman/adapters/memory/mock_embedding.py
@@ -7,6 +7,7 @@ Uses 2560-dimensional vectors to match qwen3-embedding:4b dimensions.
 
 import hashlib
 import math
+
 from typing_extensions import override
 
 from atman.core.ports.embedding import EmbeddingPort

--- a/src/atman/adapters/memory/mock_embedding.py
+++ b/src/atman/adapters/memory/mock_embedding.py
@@ -7,7 +7,7 @@ Uses 2560-dimensional vectors to match qwen3-embedding:4b dimensions.
 
 import hashlib
 import math
-from typing import override
+from typing_extensions import override
 
 from atman.core.ports.embedding import EmbeddingPort
 

--- a/src/atman/adapters/memory/ollama_embedding.py
+++ b/src/atman/adapters/memory/ollama_embedding.py
@@ -10,6 +10,7 @@ import math
 import os
 import urllib.error
 import urllib.request
+
 from typing_extensions import override
 
 from atman.core.ports.embedding import EmbeddingPort

--- a/src/atman/adapters/memory/ollama_embedding.py
+++ b/src/atman/adapters/memory/ollama_embedding.py
@@ -10,7 +10,7 @@ import math
 import os
 import urllib.error
 import urllib.request
-from typing import override
+from typing_extensions import override
 
 from atman.core.ports.embedding import EmbeddingPort
 

--- a/tests/test_memory_middleware.py
+++ b/tests/test_memory_middleware.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from typing_extensions import override
 from uuid import UUID, uuid4
+
+from typing_extensions import override
 
 from atman.core.ports.memory_middleware import MemoryContext, MemoryMiddlewarePort
 

--- a/tests/test_memory_middleware.py
+++ b/tests/test_memory_middleware.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import override
+from typing_extensions import override
 from uuid import UUID, uuid4
 
 from atman.core.ports.memory_middleware import MemoryContext, MemoryMiddlewarePort


### PR DESCRIPTION
## Summary

- Lowered `requires-python` from `>=3.12` to `>=3.11`
- Replaced `from typing import override` with `from typing_extensions import override` in 5 files — `typing.override` was added in 3.12, `typing_extensions` backports it to 3.11
- All 980 non-Ollama tests pass on Python 3.11

## Test plan

- [ ] `python3 -m pytest tests/ -m "not requires_ollama" -q` → 980 passed
- [ ] `python3 -m pytest tests/ -v` on a machine with Ollama running → all 984 tests pass

https://claude.ai/code/session_01CesYycUcjbdnRLDsurP6Vo

---
_Generated by [Claude Code](https://claude.ai/code/session_01CesYycUcjbdnRLDsurP6Vo)_