### PR TITLE
Affect Detector: markdown stripping + emphasis write trigger

### DIFF
--- a/src/atman/affect/detector.py
+++ b/src/atman/affect/detector.py
@@ -21,6 +21,7 @@ from atman.affect.emolex.emolex import emotion_score, tokenize
 from atman.affect.metrics import (
     disclaimer_density,
     emotion_lexical_energy,
+    emphasis_signal,
     hedge_density,
     length_anomaly_z,
     min_length_gate,
@@ -30,6 +31,7 @@ from atman.affect.metrics import (
     question_tail,
     self_reference_density,
     sincerity_score,
+    strip_markdown,
 )
 from atman.affect.models import AffectMetrics, AffectRecord, AgentMemoryReport, TriggerReason
 from atman.core.models.experience import ContextHalo, EmotionalDepth, FeltSense, KeyMoment
@@ -142,18 +144,31 @@ class AffectDetector:
     ) -> AffectRecord | None:
         """Analyse agent message text and optionally thinking; may append a key moment."""
         self._random_counter += 1
-        if not min_length_gate(text, self.config.min_text_length):
+
+        # Strip markdown and extract emphasized words
+        clean_text, emphasized = strip_markdown(text)
+
+        if not min_length_gate(clean_text, self.config.min_text_length):
             return None
 
-        lang = _detect_lang(text, self.config.default_lang)
-        raw_score = emotion_score(text, lang=lang)
+        lang = _detect_lang(clean_text, self.config.default_lang)
+        raw_score = emotion_score(clean_text, lang=lang)
         coverage = float(raw_score.get("_meta", {}).get("coverage", 0.0))
-        metrics = self._compute_metrics(text, lang)
+        metrics = self._compute_metrics(clean_text, lang)
         vec = self._metrics_vector(metrics)
         z = self._baseline.z_scores(vec)
 
-        char_count = len(text.strip())
+        char_count = len(clean_text.strip())
         self._baseline.update(vec, char_count=char_count, extra={"phase": "process"})
+
+        # Handle emphasis trigger unconditionally if emphasized words present
+        if emphasized:
+            await self._handle_emphasis(
+                emphasized=emphasized,
+                clean_text=clean_text,
+                lang=lang,
+                session_id=session_id,
+            )
 
         tags: list[str] = []
         reasons: list[TriggerReason] = []
@@ -188,7 +203,7 @@ class AffectDetector:
             primary = TriggerReason.ANOMALY
         else:
             primary = TriggerReason.RANDOM_SAMPLE
-        excerpt = text.strip()[:500]
+        excerpt = clean_text.strip()[:500]
         says_writes = {"text_excerpt": excerpt, "lang": lang}
         demonstrates = metrics.model_dump()
         felt = _valence_to_felt(metrics.nrc_valence, coverage)
@@ -202,6 +217,44 @@ class AffectDetector:
         if session_id is not None:
             self._append_key_moment(session_id, excerpt, felt, record)
         return record
+
+    async def _handle_emphasis(
+        self,
+        *,
+        emphasized: list[str],
+        clean_text: str,
+        lang: str,
+        session_id: UUID | None,
+    ) -> None:
+        """Handle emphasis detection: write key_moment and optionally trigger LLM analysis."""
+        signal = emphasis_signal(emphasized)
+        excerpt = clean_text.strip()[:500]
+        says_writes = {
+            "text_excerpt": excerpt,
+            "lang": lang,
+            "emphasized_words": emphasized,
+        }
+
+        # Neutral felt sense for emphasis trigger
+        felt = FeltSense(
+            emotional_valence=0.0,
+            emotional_intensity=0.5,
+            depth=EmotionalDepth.SURFACE,
+        )
+
+        record = AffectRecord(
+            trigger_reason=TriggerReason.EMPHASIS,
+            tags=["affect:emphasis"],
+            says_writes=says_writes,
+            demonstrates_thinks=signal,
+        )
+
+        if session_id is not None:
+            self._append_key_moment(session_id, excerpt, felt, record)
+
+        # LLM emotion classification (stub)
+        if self.config.use_llm_analysis:
+            raise NotImplementedError("LLM emotion classification for emphasis not yet implemented")
 
     def _append_key_moment(
         self,

--- a/src/atman/affect/metrics.py
+++ b/src/atman/affect/metrics.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import math
+import re
 from collections.abc import Sequence
+from typing import Any
 
 from atman.affect.emolex.emolex import EMOTION_KEYS, emotion_score, tokenize
 
@@ -134,6 +136,48 @@ EN_POSITIVE_SINCERITY_MARKERS = frozenset(
 
 RU_EXPANSION_AFTER = frozenset({"потому", "так", "как", "поскольку", "из-за", "это", "значит"})
 EN_EXPANSION_AFTER = frozenset({"because", "since", "therefore", "thus", "specifically", "namely"})
+
+
+def strip_markdown(text: str) -> tuple[str, list[str]]:
+    """
+    Remove bold markdown markers (**text** or __text__) and return clean text + emphasized words.
+
+    Returns:
+        Tuple of (clean_text, list_of_emphasized_words)
+
+    Examples:
+        >>> strip_markdown("**мой** блог")
+        ("мой блог", ["мой"])
+        >>> strip_markdown("no bold")
+        ("no bold", [])
+    """
+    emphasized: list[str] = []
+    # Match **text** or __text__ (non-greedy, no nested markers)
+    pattern = r"\*\*(.+?)\*\*|__(.+?)__"
+    for match in re.finditer(pattern, text):
+        word = match.group(1) or match.group(2)
+        if word:
+            emphasized.append(word)
+    # Remove all markdown bold markers
+    clean = re.sub(pattern, r"\1\2", text)
+    return clean, emphasized
+
+
+def emphasis_signal(emphasized: list[str]) -> dict[str, Any]:
+    """
+    Generate signal dictionary from emphasized words.
+
+    Args:
+        emphasized: List of words that were marked with bold in markdown
+
+    Returns:
+        Dictionary with emphasis metadata
+    """
+    return {
+        "emphasized_count": len(emphasized),
+        "emphasized_words": emphasized,
+        "total_chars": sum(len(w) for w in emphasized),
+    }
 
 
 def nrc_emotion_vector(text: str, lang: str) -> dict[str, float]:

--- a/src/atman/affect/models.py
+++ b/src/atman/affect/models.py
@@ -17,6 +17,7 @@ class TriggerReason(StrEnum):
     RANDOM_SAMPLE = "random_sample"
     SELF_REPORT = "self_report"
     DIVERGENCE = "divergence"
+    EMPHASIS = "emphasis"
 
 
 class AffectMetrics(BaseModel):

--- a/tests/affect/test_emphasis.py
+++ b/tests/affect/test_emphasis.py
@@ -1,0 +1,171 @@
+"""Tests for markdown emphasis detection in AffectDetector."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from atman.affect.detector import AffectDetector, AffectDetectorConfig
+from atman.affect.metrics import emphasis_signal, strip_markdown
+from atman.affect.models import TriggerReason
+from atman.core.models.experience import KeyMoment
+
+
+def test_strip_markdown_double_asterisk() -> None:
+    """Test **bold** markdown removal."""
+    clean, emphasized = strip_markdown("**мой** блог")
+    assert clean == "мой блог"
+    assert emphasized == ["мой"]
+
+
+def test_strip_markdown_double_underscore() -> None:
+    """Test __bold__ markdown removal."""
+    clean, emphasized = strip_markdown("This is __important__ text")
+    assert clean == "This is important text"
+    assert emphasized == ["important"]
+
+
+def test_strip_markdown_no_bold() -> None:
+    """Test text without bold markers."""
+    clean, emphasized = strip_markdown("no bold here")
+    assert clean == "no bold here"
+    assert emphasized == []
+
+
+def test_strip_markdown_multiple_bold() -> None:
+    """Test multiple bold sections."""
+    clean, emphasized = strip_markdown("**first** and **second** words")
+    assert clean == "first and second words"
+    assert emphasized == ["first", "second"]
+
+
+def test_strip_markdown_mixed_markers() -> None:
+    """Test mixed ** and __ markers."""
+    clean, emphasized = strip_markdown("**asterisk** and __underscore__")
+    assert clean == "asterisk and underscore"
+    assert emphasized == ["asterisk", "underscore"]
+
+
+def test_emphasis_signal_basic() -> None:
+    """Test emphasis_signal generates correct metadata."""
+    signal = emphasis_signal(["word1", "word2"])
+    assert signal["emphasized_count"] == 2
+    assert signal["emphasized_words"] == ["word1", "word2"]
+    assert signal["total_chars"] == 10  # 5 + 5
+
+
+def test_emphasis_signal_empty() -> None:
+    """Test emphasis_signal with empty list."""
+    signal = emphasis_signal([])
+    assert signal["emphasized_count"] == 0
+    assert signal["emphasized_words"] == []
+    assert signal["total_chars"] == 0
+
+
+@pytest.mark.asyncio
+async def test_detector_emphasis_trigger_creates_key_moment(tmp_path: Path) -> None:
+    """Test that text with emphasis creates affect:emphasis key_moment."""
+    captured: list[KeyMoment] = []
+
+    def sink(_sid: UUID, km: KeyMoment) -> None:
+        captured.append(km)
+
+    det = AffectDetector(
+        AffectDetectorConfig(cold_start_sessions=0),
+        workspace=tmp_path,
+        append_moment=sink,
+    )
+
+    sid = UUID("018e5a2b-0000-0000-0000-000000000001")
+    await det.process("This **слово** is important", session_id=sid)
+
+    # Should have one emphasis key_moment
+    emphasis_moments = [km for km in captured if "affect:emphasis" in km.values_touched]
+    assert len(emphasis_moments) == 1
+
+    km = emphasis_moments[0]
+    meta = km.context_halo
+    assert meta is not None
+    assert meta.metadata["trigger_reason"] == TriggerReason.EMPHASIS.value
+    assert "affect:emphasis" in meta.metadata["tags"]
+    assert meta.metadata["says_writes"]["emphasized_words"] == ["слово"]
+
+
+@pytest.mark.asyncio
+async def test_detector_no_emphasis_no_trigger(tmp_path: Path) -> None:
+    """Test that text without emphasis does not create affect:emphasis record."""
+    captured: list[KeyMoment] = []
+
+    def sink(_sid: UUID, km: KeyMoment) -> None:
+        captured.append(km)
+
+    det = AffectDetector(
+        AffectDetectorConfig(cold_start_sessions=0),
+        workspace=tmp_path,
+        append_moment=sink,
+    )
+
+    sid = UUID("018e5a2b-0000-0000-0000-000000000002")
+    await det.process("Plain text without bold", session_id=sid)
+
+    # Should have no emphasis key_moments
+    emphasis_moments = [km for km in captured if "affect:emphasis" in km.values_touched]
+    assert len(emphasis_moments) == 0
+
+
+@pytest.mark.asyncio
+async def test_detector_emphasis_with_llm_analysis_raises(tmp_path: Path) -> None:
+    """Test that use_llm_analysis=True with emphasis raises NotImplementedError."""
+    captured: list[KeyMoment] = []
+
+    def sink(_sid: UUID, km: KeyMoment) -> None:
+        captured.append(km)
+
+    det = AffectDetector(
+        AffectDetectorConfig(cold_start_sessions=0, use_llm_analysis=True),
+        workspace=tmp_path,
+        append_moment=sink,
+    )
+
+    sid = UUID("018e5a2b-0000-0000-0000-000000000003")
+
+    with pytest.raises(NotImplementedError, match="LLM emotion classification"):
+        await det.process("This **word** is emphasized", session_id=sid)
+
+
+@pytest.mark.asyncio
+async def test_detector_emphasis_stripped_before_metrics(tmp_path: Path) -> None:
+    """Test that markdown is stripped before metric computation."""
+    captured: list[KeyMoment] = []
+
+    def sink(_sid: UUID, km: KeyMoment) -> None:
+        captured.append(km)
+
+    det = AffectDetector(
+        AffectDetectorConfig(
+            cold_start_sessions=0,
+            random_sample_every_n=1,  # Always sample
+        ),
+        workspace=tmp_path,
+        append_moment=sink,
+    )
+
+    sid = UUID("018e5a2b-0000-0000-0000-000000000004")
+    # Text long enough to trigger metrics and has bold
+    await det.process("**Important** message with sufficient length for analysis", session_id=sid)
+
+    # Should have both emphasis and random-sample moments
+    assert len(captured) >= 2
+    emphasis_moments = [km for km in captured if "affect:emphasis" in km.values_touched]
+    assert len(emphasis_moments) == 1
+
+    # Check that demonstrates_thinks in emphasis record has signal
+    km = emphasis_moments[0]
+    meta = km.context_halo
+    assert meta is not None
+    demonstrates = meta.metadata.get("demonstrates_thinks")
+    assert demonstrates is not None
+    assert demonstrates["emphasized_count"] == 1
+    assert demonstrates["emphasized_words"] == ["Important"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends E21 Affect Detector with bold emphasis detection. Text with markdown bold markers (`**text**` or `__text__`) now triggers an unconditional `affect:emphasis` key_moment record.

## Changes

### Core Implementation
- **`src/atman/affect/models.py`**: Added `TriggerReason.EMPHASIS` enum value
- **`src/atman/affect/metrics.py`**: 
  - Added `strip_markdown(text) -> tuple[str, list[str]]` to extract bold text and clean markdown
  - Added `emphasis_signal(emphasized) -> dict` to generate emphasis metadata
- **`src/atman/affect/detector.py`**:
  - Modified `process()` to call `strip_markdown()` before computing metrics
  - Added `_handle_emphasis()` method to write `affect:emphasis` key_moments
  - LLM emotion classification path stubs with `NotImplementedError` when `use_llm_analysis=True`

### Tests
- **`tests/affect/test_emphasis.py`**: 11 comprehensive tests covering:
  - `strip_markdown()` with `**bold**` and `__bold__` markers
  - Multiple bold sections and mixed markers
  - Empty and non-empty emphasis lists
  - Integration with detector: emphasis triggers, no-emphasis cases, LLM stub exception
  - Verification that markdown is stripped before metrics computation

## Validation

All acceptance criteria met:

```bash
# ✅ Tests pass with ≥8 tests (11 total)
pytest tests/affect/test_emphasis.py -v --tb=short
# 11 passed in 0.24s

# ✅ Strict type checking passes
mypy --strict src/atman/affect/
# Success: no issues found in 7 source files

# ✅ Full quality checks pass
ruff check src/ tests/          # All checks passed!
ruff format --check src/ tests/ # 191 files already formatted
pyright src/ tests/             # 0 errors, 0 warnings, 0 informations
bandit -c pyproject.toml -r src/atman/  # No issues identified
pytest tests/ --cov=atman --cov-fail-under=90  # 1176 passed, coverage ≥90%
```

## Examples

```python
# Basic usage
clean, emphasized = strip_markdown("**мой** блог")
assert clean == "мой блог"
assert emphasized == ["мой"]

# No bold
clean, emphasized = strip_markdown("no bold")
assert clean == "no bold"
assert emphasized == []

# Detector integration
await detector.process("This **слово** is important", session_id=sid)
# Creates key_moment with tag="affect:emphasis", 
# says_writes["emphasized_words"] = ["слово"]
```

## Out of Scope
- ❌ Italic markers (single `*` or `_`) — only double markers handled
- ❌ Full LLM emotion classification — stub raises `NotImplementedError`
- ❌ Changes to `emolex.py`

## System Map Updates

**Modules affected (§1)**:
- `src/atman/affect/models.py` — added `EMPHASIS` trigger reason
- `src/atman/affect/metrics.py` — added markdown stripping + emphasis signal functions
- `src/atman/affect/detector.py` — integrated emphasis detection into `process()` flow

**Integration coverage (§2)**:
- detector → metrics: `strip_markdown()` called before all metric computation
- detector → storage: emphasis triggers unconditional key_moment writes via `_append_key_moment()`

**Tests coverage**:
- **Unit tests** (`test_emphasis.py`): `strip_markdown()`, `emphasis_signal()` normal/edge cases
- **Integration tests** (`test_emphasis.py`): detector with/without emphasis, LLM stub exception
- **System tests**: covered by existing `test_e2e_full_cli.py` (detector flows through Session Manager)

**Edge cases closed**:
- Empty emphasis list → no key_moment created ✅
- Invalid/malformed markdown → handled gracefully by regex (unmatched markers ignored) ✅
- `use_llm_analysis=True` → explicit `NotImplementedError` raised ✅

## Dependencies
- Depends on: E21 Affect Detector baseline (already merged)
- Blocks: None

---

**Checklist**:
- [x] All acceptance criteria met
- [x] Tests pass (`pytest tests/affect/test_emphasis.py -v`)
- [x] Type checks pass (`mypy --strict src/atman/affect/`)
- [x] Lint/format/security checks pass
- [x] Coverage ≥90%
- [x] English docs updated (inline docstrings)
- [x] Commits follow conventional format
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce1fe6bf-a76e-4ef6-9075-f5b0c7ce3f3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce1fe6bf-a76e-4ef6-9075-f5b0c7ce3f3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

