### PR TITLE
feat: Config extensions for E22.1 - Add context_limit and session fields

### DIFF
--- a/docs/architecture/SYSTEM_MAP-ru.md
+++ b/docs/architecture/SYSTEM_MAP-ru.md
@@ -101,6 +101,10 @@
 | `adapters/storage/reflection_persistence_helper.py` | — | **E27**: функции-помощники для персистенса рефлексий (`persist_micro_reflection`, `persist_daily_reflection`, `persist_deep_reflection`) |
 | `adapters/reflection/mock_reflection_model.py` (`MockReflectionModel`) | `ReflectionModel` | детерминированный мок |
 | `adapters/reflection/fixture_loader.py` | — | загрузка фикстур для демо |
+| `adapters/agent/config.py` (`ModelConfig`, `AgentConfig`) | — | конфигурация Pydantic AI модели + среды выполнения агента: лимиты контекстного окна, таймаут сессии, переключатель свободного времени, видимость монолога (E22.1, E26-R1, E26-R2, E26-R4) |
+| `adapters/agent/deps.py` (`AtmanDeps`, `AtmanDeps.from_config`) | — | замороженный DI-контейнер, связывающий `SessionManager`, `IdentityService`, `ExperienceService`, `MicroReflectionService`, `StateStore`; фабрика `from_config` переносит валидированные лимиты из `AgentConfig` |
+| `adapters/agent/instructions.py` (`build_instructions`) | — | строит динамический system prompt из текущих `Identity` + `NarrativeDocument` (с усечением по `AtmanDeps.truncate_narrative_*`) |
+| `adapters/agent/tools.py` (`record_key_moment` async, `log_experience`) | — | инструменты Pydantic AI: `record_key_moment` → `AffectDetector.submit_self_report` когда `SessionManager` настроен на аффект; `log_experience` — redirect-заглушка |
 
 ### 1.6. CLI / TUI / Web / Демо
 

--- a/docs/architecture/SYSTEM_MAP.md
+++ b/docs/architecture/SYSTEM_MAP.md
@@ -97,7 +97,7 @@ All paths are absolute relative to the repository root.
 | `adapters/storage/reflection_persistence_helper.py` | — | **E27**: helper functions for persisting reflections (`persist_micro_reflection`, `persist_daily_reflection`, `persist_deep_reflection`) |
 | `adapters/reflection/mock_reflection_model.py` (`MockReflectionModel`) | `ReflectionModel` | deterministic mock |
 | `adapters/reflection/fixture_loader.py` | — | load fixtures for demos |
-| `adapters/agent/config.py` (`ModelConfig`, `AgentConfig`) | — | Pydantic AI model + agent runtime config (E26-R1, E26-R2, E26-R4) |
+| `adapters/agent/config.py` (`ModelConfig`, `AgentConfig`) | — | Pydantic AI model + agent runtime config: context window limits, session timeout, free-time toggle, monologue visibility (E22.1, E26-R1, E26-R2, E26-R4) |
 | `adapters/agent/deps.py` (`AtmanDeps`, `AtmanDeps.from_config`) | — | frozen DI container wiring `SessionManager`, `IdentityService`, `ExperienceService`, `MicroReflectionService`, `StateStore`; `from_config` factory transfers validated limits from `AgentConfig` |
 | `adapters/agent/instructions.py` (`build_instructions`) | — | builds dynamic system prompt from current `Identity` + `NarrativeDocument` (truncated per `AtmanDeps.truncate_narrative_*`) |
 | `adapters/agent/tools.py` (`record_key_moment` async, `log_experience`) | — | Pydantic AI tools: `record_key_moment` → `AffectDetector.submit_self_report` when `SessionManager` is configured with affect; `log_experience` redirect stub |

--- a/src/atman/adapters/agent/config.py
+++ b/src/atman/adapters/agent/config.py
@@ -36,6 +36,11 @@ class ModelConfig(BaseModel):
         gt=0,
         description="Maximum tokens for model response",
     )
+    context_limit: int = Field(
+        default=8192,
+        gt=0,
+        description="Maximum context window size for the model",
+    )
 
 
 class AgentConfig(BaseModel):
@@ -74,6 +79,24 @@ class AgentConfig(BaseModel):
     enable_key_moments: bool = Field(
         default=True,
         description="Enable record_key_moment tool",
+    )
+    context_tail_messages: int = Field(
+        default=10,
+        gt=0,
+        description="Number of recent messages to retain in context window",
+    )
+    session_timeout_minutes: int = Field(
+        default=7,
+        gt=0,
+        description="Session timeout in minutes before automatic termination",
+    )
+    enable_free_time: bool = Field(
+        default=True,
+        description="Enable free time processing between sessions",
+    )
+    show_agent_monologue: bool = Field(
+        default=False,
+        description="Display agent internal reasoning and thought process",
     )
 
     model: ModelConfig = Field(default_factory=ModelConfig)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## PLAYBOOK markers

- [x] I introduced no generalizable patterns (pure refactoring / project-specific changes)

*This PR adds configuration fields without introducing new engineering patterns.*

---

## Что сделано

Добавлены новые поля конфигурации в `ModelConfig` и `AgentConfig` согласно спецификации #E22.1:

**ModelConfig:**
- `context_limit: int = 8192` — максимальный размер контекстного окна модели

**AgentConfig:**
- `context_tail_messages: int = 10` — количество последних сообщений для сохранения в контексте
- `session_timeout_minutes: int = 7` — таймаут сессии в минутах
- `enable_free_time: bool = True` — включение обработки свободного времени между сессиями
- `show_agent_monologue: bool = False` — отображение внутренних рассуждений агента

Все поля имеют безопасные значения по умолчанию и валидацию через Pydantic.

**Документация:**
- Обновлена `docs/architecture/SYSTEM_MAP.md` — расширено описание `config.py` с упоминанием новых возможностей
- Обновлена `docs/architecture/SYSTEM_MAP-ru.md` — добавлены недостающие записи про agent-адаптеры для синхронизации с английской версией

## Как воспроизвести (демонстрация)

**N/A** — изменения касаются только внутренних полей конфигурации, которые будут использованы в последующих задачах E22.2-E22.6. Поля не связаны напрямую с пользовательским поведением до момента их подключения в runner.

**Валидация:**
```bash
python3 -c "from atman.adapters.agent.config import ModelConfig, AgentConfig; m=ModelConfig(); a=AgentConfig(); assert m.context_limit and a.session_timeout_minutes"
```

## Тип изменений

- [x] Новая возможность / документация

## Карта системы

- **Затронутые разделы карты:** §1.5 Адаптеры — обновлено описание `adapters/agent/config.py` с упоминанием новых полей E22.1
- **Покрытие тестами:** существующие тесты валидируют Pydantic-модели; новые поля с дефолтами автоматически проходят сериализацию (`test_serialization_roundtrip.py`)
- **Закрытые GAP'ы из §4.5:** N/A
- **Карта обновлена:**
  - [x] `docs/architecture/SYSTEM_MAP.md` — расширено описание config.py (строка 100)
  - [x] `SYSTEM_MAP-ru.md` — добавлены недостающие agent-адаптеры (config.py, deps.py, instructions.py, tools.py)

## Тесты-страховки агентной разработки

**N/A** — изменения касаются только добавления новых полей в существующие Pydantic-модели с дефолтными значениями. Существующие тесты продолжают работать без модификаций. Контрактные тесты не требуют обновления, так как:
- Поля добавлены с дефолтами (обратно совместимо)
- Сериализация/десериализация работает автоматически через Pydantic
- CLI-команды не затронуты
- Бизнес-инварианты не изменены

## Чеклист

- [x] Описание соответствует фактическим изменениям
- [x] При необходимости обновлены `README` / `docs` / демо-сценарий (N/A — конфигурационные поля)
- [x] При необходимости обновлены `docs/architecture/SYSTEM_MAP.md` и `SYSTEM_MAP-ru.md` ✓
- [x] `ruff check src/ tests/` — 0 ошибок ✓
- [x] `ruff format --check src/ tests/` — 0 ошибок ✓
- [x] `pyright src/ tests/` — 0 ошибок ✓
- [x] `bandit -c pyproject.toml -r src/atman/` — 0 ошибок ✓
- [x] `pytest tests/ -v --cov=atman --cov-fail-under=90` — тесты проходят, покрытие ≥90% ✓
- [x] GitHub Actions CI зелёный или локальные проверки выше объясняют, почему CI не применим

## Примечания

**Связь с другими задачами:** Эти поля будут использованы в задачах E22.2-E22.6 для реализации управления контекстом и сессиями.

**Риски:** Отсутствуют — все поля имеют безопасные значения по умолчанию и не меняют текущее поведение до момента их явного использования в коде.

**Обратная совместимость:** Полная — все поля опциональны с дефолтами.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65542ec1-176f-4133-b0b3-a8e969b8af96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65542ec1-176f-4133-b0b3-a8e969b8af96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

