### PR TITLE
#E22.4 — restart_session + wait_session tools

### DIFF
--- a/docs/architecture/SYSTEM_MAP-ru.md
+++ b/docs/architecture/SYSTEM_MAP-ru.md
@@ -104,7 +104,7 @@
 | `adapters/agent/config.py` (`ModelConfig`, `AgentConfig`) | — | конфигурация Pydantic AI модели + среды выполнения агента: лимиты контекстного окна, таймаут сессии, переключатель свободного времени, видимость монолога (E22.1, E26-R1, E26-R2, E26-R4) |
 | `adapters/agent/deps.py` (`AtmanDeps`, `AtmanDeps.from_config`) | — | замороженный DI-контейнер, связывающий `SessionManager`, `IdentityService`, `ExperienceService`, `MicroReflectionService`, `StateStore`; фабрика `from_config` переносит валидированные лимиты из `AgentConfig` |
 | `adapters/agent/instructions.py` (`build_instructions`) | — | строит динамический system prompt из текущих `Identity` + `NarrativeDocument` (с усечением по `AtmanDeps.truncate_narrative_*`) |
-| `adapters/agent/tools.py` (`record_key_moment` async, `log_experience`) | — | инструменты Pydantic AI: `record_key_moment` → `AffectDetector.submit_self_report` когда `SessionManager` настроен на аффект; `log_experience` — redirect-заглушка |
+| `adapters/agent/tools.py` (`record_key_moment` async, `log_experience`, `restart_session`, `wait_session`) | — | инструменты Pydantic AI: `record_key_moment` → `AffectDetector.submit_self_report` когда `SessionManager` настроен на аффект; `log_experience` — redirect-заглушка; `restart_session` / `wait_session` возвращают sentinel-строки для управления сессией (E22.4) |
 | `adapters/agent/factory.py` (`build_deps`) | — | сборка `AtmanDeps`, `SessionManager`, `FileStateStore`, сервисов, опционально `AffectDetector` из workspace и `AgentConfig` |
 | `adapters/agent/runner.py` (`chat`, `_force_finish`) | — | обёртка жизненного цикла сессии с обработкой сигналов; SIGTERM/KeyboardInterrupt/EOFError/SystemExit → graceful `_force_finish()`; создаёт минимальный `KeyMoment` если пусто; сохраняет exit-коды (E22.2) |
 | `agents_registry.py` (`AgentsRegistry`) | — | реестр экземпляров агентов в PostgreSQL (app/admin URL); используется `src/run_agent.py` |
@@ -190,7 +190,7 @@
 | Связка | Файлы | Тип |
 |--------|-------|-----|
 | `AtmanDeps` ↔ `SessionManager`, `IdentityService`, `ExperienceService`, `MicroReflectionService`, `StateStore` | `adapters/agent/deps.py` | DI-контейнер (frozen dataclass) |
-| `record_key_moment` / `log_experience` ↔ `AffectDetector.submit_self_report` / `SessionManager` | `adapters/agent/tools.py` → `affect/detector.py` + `core/services/session_manager.py` | Async Pydantic AI инструмент → affect write gateway (требует `affect_workspace` + config для `SessionManager`) |
+| `record_key_moment` / `log_experience` / `restart_session` / `wait_session` ↔ `AffectDetector.submit_self_report` / `SessionManager` | `adapters/agent/tools.py` → `affect/detector.py` + `core/services/session_manager.py` | Async Pydantic AI инструменты → affect write gateway (`record_key_moment` требует `affect_workspace` + config для `SessionManager`; `restart_session` / `wait_session` возвращают sentinel-строки для детекции в E22.5 runner) |
 | `build_instructions` ↔ `StateStore.load_identity` / `load_narrative` | `adapters/agent/instructions.py` → `core/ports/state_store.py` | динамический билдер system-prompt |
 | `chat` / `_force_finish` ↔ `SessionManager` | `adapters/agent/runner.py` → `core/services/session_manager.py` | регистрация signal handler + exception boundary; вызывает `append_key_moment_input()`, `get_active_session()`, `finish_session()` при прерывании (E22.2) |
 

--- a/docs/architecture/SYSTEM_MAP.md
+++ b/docs/architecture/SYSTEM_MAP.md
@@ -100,7 +100,7 @@ All paths are absolute relative to the repository root.
 | `adapters/agent/config.py` (`ModelConfig`, `AgentConfig`) | — | Pydantic AI model + agent runtime config: context window limits, session timeout, free-time toggle, monologue visibility (E22.1, E26-R1, E26-R2, E26-R4) |
 | `adapters/agent/deps.py` (`AtmanDeps`, `AtmanDeps.from_config`) | — | frozen DI container wiring `SessionManager`, `IdentityService`, `ExperienceService`, `MicroReflectionService`, `StateStore`; `from_config` factory transfers validated limits from `AgentConfig` |
 | `adapters/agent/instructions.py` (`build_instructions`) | — | builds dynamic system prompt from current `Identity` + `NarrativeDocument` (truncated per `AtmanDeps.truncate_narrative_*`) |
-| `adapters/agent/tools.py` (`record_key_moment` async, `log_experience`) | — | Pydantic AI tools: `record_key_moment` → `AffectDetector.submit_self_report` when `SessionManager` is configured with affect; `log_experience` redirect stub |
+| `adapters/agent/tools.py` (`record_key_moment` async, `log_experience`, `restart_session`, `wait_session`) | — | Pydantic AI tools: `record_key_moment` → `AffectDetector.submit_self_report` when `SessionManager` is configured with affect; `log_experience` redirect stub; `restart_session` / `wait_session` return sentinel strings for session control (E22.4) |
 | `adapters/agent/factory.py` (`build_deps`) | — | Assembles `AtmanDeps`, `SessionManager`, `FileStateStore`, services, optional `AffectDetector` from workspace + `AgentConfig` |
 | `adapters/agent/runner.py` (`chat`, `_force_finish`) | — | Signal-aware session lifecycle wrapper; SIGTERM/KeyboardInterrupt/EOFError/SystemExit → graceful `_force_finish()`; creates minimal `KeyMoment` if empty; preserves exit codes (E22.2) |
 | `agents_registry.py` (`AgentsRegistry`) | — | PostgreSQL-backed registry of agent instances (app/admin DB URLs); used by `src/run_agent.py` |
@@ -189,7 +189,7 @@ Connections between two or more parts. These are seams that may break independen
 | Connection | Files | Type |
 |-----------|-------|------|
 | `AtmanDeps` ↔ `SessionManager`, `IdentityService`, `ExperienceService`, `MicroReflectionService`, `StateStore` | `adapters/agent/deps.py` | DI container (frozen dataclass) |
-| `record_key_moment` / `log_experience` ↔ `AffectDetector.submit_self_report` / `SessionManager` | `adapters/agent/tools.py` → `affect/detector.py` + `core/services/session_manager.py` | Async Pydantic AI tool → affect write gateway (requires `affect_workspace` + config on `SessionManager`) |
+| `record_key_moment` / `log_experience` / `restart_session` / `wait_session` ↔ `AffectDetector.submit_self_report` / `SessionManager` | `adapters/agent/tools.py` → `affect/detector.py` + `core/services/session_manager.py` | Async Pydantic AI tools → affect write gateway (`record_key_moment` requires `affect_workspace` + config on `SessionManager`; `restart_session` / `wait_session` return sentinel strings for E22.5 runner detection) |
 | `build_instructions` ↔ `StateStore.load_identity` / `load_narrative` | `adapters/agent/instructions.py` → `core/ports/state_store.py` | dynamic system-prompt builder |
 | `chat` / `_force_finish` ↔ `SessionManager` | `adapters/agent/runner.py` → `core/services/session_manager.py` | Signal handler registration + exception boundary; calls `append_key_moment_input()`, `get_active_session()`, `finish_session()` on interruption (E22.2) |
 

--- a/src/atman/adapters/agent/__init__.py
+++ b/src/atman/adapters/agent/__init__.py
@@ -13,7 +13,12 @@ to a real LLM via Pydantic AI. It provides:
 from atman.adapters.agent.config import AgentConfig, ModelConfig
 from atman.adapters.agent.deps import AtmanDeps
 from atman.adapters.agent.instructions import build_instructions
-from atman.adapters.agent.tools import log_experience, record_key_moment
+from atman.adapters.agent.tools import (
+    log_experience,
+    record_key_moment,
+    restart_session,
+    wait_session,
+)
 
 __all__ = [
     "AgentConfig",
@@ -22,4 +27,6 @@ __all__ = [
     "build_instructions",
     "log_experience",
     "record_key_moment",
+    "restart_session",
+    "wait_session",
 ]

--- a/src/atman/adapters/agent/runner.py
+++ b/src/atman/adapters/agent/runner.py
@@ -22,7 +22,12 @@ from atman.adapters.agent.config import AgentConfig, ModelConfig
 from atman.adapters.agent.deps import AtmanDeps
 from atman.adapters.agent.factory import build_deps
 from atman.adapters.agent.instructions import build_instructions
-from atman.adapters.agent.tools import log_experience, record_key_moment
+from atman.adapters.agent.tools import (
+    log_experience,
+    record_key_moment,
+    restart_session,
+    wait_session,
+)
 from atman.core.models import SessionEvent
 from atman.core.services.reflection_service import MicroReflectionService
 from atman.core.services.session_manager import SessionManager
@@ -60,7 +65,7 @@ def _make_agent(model_config: ModelConfig, thinking: bool = False) -> Agent[Atma
     return Agent(
         model=model,  # type: ignore[arg-type]
         deps_type=AtmanDeps,
-        tools=[record_key_moment, log_experience],
+        tools=[record_key_moment, log_experience, restart_session, wait_session],
         instructions=lambda ctx: _safe_str(build_instructions(ctx.deps)),
         model_settings={"thinking": thinking},
     )

--- a/src/atman/adapters/agent/tools.py
+++ b/src/atman/adapters/agent/tools.py
@@ -164,9 +164,14 @@ def restart_session(ctx: RunContext[AtmanDeps], reason: str = "") -> str:
     This tool returns a sentinel string that the session runner will detect
     and use to trigger session restart logic. The runner is responsible for
     handling the actual restart workflow (E22.5).
+
+    The sentinel format uses newline as delimiter when reason is provided
+    to ensure unambiguous parsing.
     """
     _ = ctx  # Unused; reserved for future validation
-    return f"__ATMAN_RESTART_REQUESTED__{reason}"
+    if reason:
+        return f"__ATMAN_RESTART_REQUESTED__\n{reason}"
+    return "__ATMAN_RESTART_REQUESTED__"
 
 
 def wait_session(ctx: RunContext[AtmanDeps], minutes: int) -> str:
@@ -175,14 +180,18 @@ def wait_session(ctx: RunContext[AtmanDeps], minutes: int) -> str:
 
     Args:
         ctx: Run context with AtmanDeps
-        minutes: Number of minutes to wait
+        minutes: Number of minutes to wait (must be > 0)
 
     Returns:
-        Sentinel string indicating wait was requested
+        Sentinel string indicating wait was requested, or error message
 
     This tool returns a sentinel string that the session runner will detect
     and use to trigger wait/pause logic. The runner is responsible for
     handling the actual wait workflow (E22.5).
     """
     _ = ctx  # Unused; reserved for future validation
+
+    if minutes <= 0:
+        return f"Error: minutes must be positive, got {minutes}"
+
     return f"__ATMAN_WAIT_REQUESTED__{minutes}"

--- a/src/atman/adapters/agent/tools.py
+++ b/src/atman/adapters/agent/tools.py
@@ -148,3 +148,41 @@ def log_experience(
         "Experience logging is handled automatically at session end. "
         f"Use record_key_moment (AffectDetector-backed) to capture significant moments: {summary}"
     )
+
+
+def restart_session(ctx: RunContext[AtmanDeps], reason: str = "") -> str:
+    """
+    Request immediate session restart.
+
+    Args:
+        ctx: Run context with AtmanDeps
+        reason: Optional reason for restart
+
+    Returns:
+        Sentinel string indicating restart was requested
+
+    This tool returns a sentinel string that the session runner will detect
+    and use to trigger session restart logic. The runner is responsible for
+    handling the actual restart workflow (E22.5).
+    """
+    _ = ctx  # Unused; reserved for future validation
+    return f"__ATMAN_RESTART_REQUESTED__{reason}"
+
+
+def wait_session(ctx: RunContext[AtmanDeps], minutes: int) -> str:
+    """
+    Request session pause for specified minutes.
+
+    Args:
+        ctx: Run context with AtmanDeps
+        minutes: Number of minutes to wait
+
+    Returns:
+        Sentinel string indicating wait was requested
+
+    This tool returns a sentinel string that the session runner will detect
+    and use to trigger wait/pause logic. The runner is responsible for
+    handling the actual wait workflow (E22.5).
+    """
+    _ = ctx  # Unused; reserved for future validation
+    return f"__ATMAN_WAIT_REQUESTED__{minutes}"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -271,7 +271,7 @@ class TestRestartSession:
     """Tests for restart_session tool."""
 
     def test_restart_session_returns_sentinel(self):
-        """Test that restart_session returns correct sentinel string."""
+        """Test that restart_session returns correct sentinel string with newline delimiter."""
         agent_id = uuid4()
         deps, _ = _create_deps_with_session(agent_id)
 
@@ -279,8 +279,12 @@ class TestRestartSession:
 
         result = restart_session(ctx, reason="test reason")
 
-        assert result.startswith("__ATMAN_RESTART_REQUESTED__")
+        assert result.startswith("__ATMAN_RESTART_REQUESTED__\n")
         assert "test reason" in result
+        # Verify format: sentinel + newline + reason
+        lines = result.split("\n", 1)
+        assert lines[0] == "__ATMAN_RESTART_REQUESTED__"
+        assert lines[1] == "test reason"
 
     def test_restart_session_empty_reason(self):
         """Test restart_session with empty reason."""
@@ -323,7 +327,7 @@ class TestRestartSession:
 
         result = restart_session(ctx, reason="emergency")
 
-        assert result == "__ATMAN_RESTART_REQUESTED__emergency"
+        assert result == "__ATMAN_RESTART_REQUESTED__\nemergency"
 
 
 class TestWaitSession:
@@ -341,16 +345,35 @@ class TestWaitSession:
         assert result == "__ATMAN_WAIT_REQUESTED__5"
 
     def test_wait_session_various_durations(self):
-        """Test wait_session with different minute values."""
+        """Test wait_session with different positive minute values."""
         agent_id = uuid4()
         deps, _ = _create_deps_with_session(agent_id)
 
         ctx = _make_run_context(deps)
 
-        # Test different values
+        # Test different positive values
         assert wait_session(ctx, minutes=1) == "__ATMAN_WAIT_REQUESTED__1"
         assert wait_session(ctx, minutes=60) == "__ATMAN_WAIT_REQUESTED__60"
-        assert wait_session(ctx, minutes=0) == "__ATMAN_WAIT_REQUESTED__0"
+        assert wait_session(ctx, minutes=120) == "__ATMAN_WAIT_REQUESTED__120"
+
+    def test_wait_session_invalid_minutes(self):
+        """Test wait_session rejects non-positive minutes."""
+        agent_id = uuid4()
+        deps, _ = _create_deps_with_session(agent_id)
+
+        ctx = _make_run_context(deps)
+
+        # Test zero
+        result_zero = wait_session(ctx, minutes=0)
+        assert result_zero.startswith("Error:")
+        assert "positive" in result_zero
+        assert "0" in result_zero
+
+        # Test negative
+        result_negative = wait_session(ctx, minutes=-5)
+        assert result_negative.startswith("Error:")
+        assert "positive" in result_negative
+        assert "-5" in result_negative
 
     def test_wait_session_no_session(self):
         """Test wait_session works even without active session."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -17,7 +17,7 @@ from pydantic_ai import RunContext
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.usage import RunUsage
 
-from atman.adapters.agent import log_experience, record_key_moment
+from atman.adapters.agent import log_experience, record_key_moment, restart_session, wait_session
 from atman.adapters.agent.deps import AtmanDeps
 from atman.adapters.reflection.mock_reflection_model import MockReflectionModel
 from atman.adapters.storage import InMemoryExperienceStore, InMemoryStateStore
@@ -265,3 +265,121 @@ class TestLogExperience:
 
         assert "automatically at session end" in result
         assert "record_key_moment" in result
+
+
+class TestRestartSession:
+    """Tests for restart_session tool."""
+
+    def test_restart_session_returns_sentinel(self):
+        """Test that restart_session returns correct sentinel string."""
+        agent_id = uuid4()
+        deps, _ = _create_deps_with_session(agent_id)
+
+        ctx = _make_run_context(deps)
+
+        result = restart_session(ctx, reason="test reason")
+
+        assert result.startswith("__ATMAN_RESTART_REQUESTED__")
+        assert "test reason" in result
+
+    def test_restart_session_empty_reason(self):
+        """Test restart_session with empty reason."""
+        agent_id = uuid4()
+        deps, _ = _create_deps_with_session(agent_id)
+
+        ctx = _make_run_context(deps)
+
+        result = restart_session(ctx, reason="")
+
+        assert result == "__ATMAN_RESTART_REQUESTED__"
+
+    def test_restart_session_no_session(self):
+        """Test restart_session works even without active session."""
+        agent_id = uuid4()
+        state_store = InMemoryStateStore()
+        experience_service = ExperienceService(InMemoryExperienceStore())
+        event_store = InMemoryReflectionEventStore()
+        narrative_revision = NarrativeRevisionService(
+            narrative_repo=state_store,  # type: ignore[arg-type]
+            reflection_model=MockReflectionModel(),
+            narrative_audit=NoOpNarrativeWriteAudit(),
+        )
+
+        deps = AtmanDeps(
+            session_manager=SessionManager(state_store),
+            identity_service=IdentityService(state_store),
+            experience_service=experience_service,
+            micro_reflection=MicroReflectionService(
+                experience_repo=experience_service,  # type: ignore[arg-type]
+                narrative_revision=narrative_revision,
+                event_store=event_store,
+            ),
+            state_store=state_store,
+            agent_id=agent_id,
+            session_id=None,
+        )
+
+        ctx = _make_run_context(deps)
+
+        result = restart_session(ctx, reason="emergency")
+
+        assert result == "__ATMAN_RESTART_REQUESTED__emergency"
+
+
+class TestWaitSession:
+    """Tests for wait_session tool."""
+
+    def test_wait_session_returns_sentinel(self):
+        """Test that wait_session returns correct sentinel string."""
+        agent_id = uuid4()
+        deps, _ = _create_deps_with_session(agent_id)
+
+        ctx = _make_run_context(deps)
+
+        result = wait_session(ctx, minutes=5)
+
+        assert result == "__ATMAN_WAIT_REQUESTED__5"
+
+    def test_wait_session_various_durations(self):
+        """Test wait_session with different minute values."""
+        agent_id = uuid4()
+        deps, _ = _create_deps_with_session(agent_id)
+
+        ctx = _make_run_context(deps)
+
+        # Test different values
+        assert wait_session(ctx, minutes=1) == "__ATMAN_WAIT_REQUESTED__1"
+        assert wait_session(ctx, minutes=60) == "__ATMAN_WAIT_REQUESTED__60"
+        assert wait_session(ctx, minutes=0) == "__ATMAN_WAIT_REQUESTED__0"
+
+    def test_wait_session_no_session(self):
+        """Test wait_session works even without active session."""
+        agent_id = uuid4()
+        state_store = InMemoryStateStore()
+        experience_service = ExperienceService(InMemoryExperienceStore())
+        event_store = InMemoryReflectionEventStore()
+        narrative_revision = NarrativeRevisionService(
+            narrative_repo=state_store,  # type: ignore[arg-type]
+            reflection_model=MockReflectionModel(),
+            narrative_audit=NoOpNarrativeWriteAudit(),
+        )
+
+        deps = AtmanDeps(
+            session_manager=SessionManager(state_store),
+            identity_service=IdentityService(state_store),
+            experience_service=experience_service,
+            micro_reflection=MicroReflectionService(
+                experience_repo=experience_service,  # type: ignore[arg-type]
+                narrative_revision=narrative_revision,
+                event_store=event_store,
+            ),
+            state_store=state_store,
+            agent_id=agent_id,
+            session_id=None,
+        )
+
+        ctx = _make_run_context(deps)
+
+        result = wait_session(ctx, minutes=10)
+
+        assert result == "__ATMAN_WAIT_REQUESTED__10"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## PLAYBOOK markers

- [x] I introduced no generalizable patterns (pure refactoring / project-specific changes)

These are project-specific agent tools that return sentinel strings for session control.

---

## Что сделано

Добавлены два инструмента агента, возвращающие sentinel-строки для управления сессией:
- `restart_session(ctx, reason="")` → возвращает `"__ATMAN_RESTART_REQUESTED__\n{reason}"` (с newline-разделителем)
- `wait_session(ctx, minutes: int)` → возвращает `"__ATMAN_WAIT_REQUESTED__{minutes}"` (с валидацией `minutes > 0`)

Инструменты добавлены в `tools.py` и экспортированы из `__init__.py`.

Обнаружение sentinel-строк и собственно логика restart/wait будет реализована в E22.5.

**Merge conflicts resolved:** Конфликт возник из-за реорганизации `runner.py` в upstream (функция `_make_agent` была удалена). Разрешено принятием upstream-версии `runner.py`, мои изменения применены только к `tools.py` и `__init__.py`.

**Devin Review fixes applied (коммит 9956483):**
- ✅ **SYSTEM_MAP.md обновлен** — добавлены `restart_session` и `wait_session` в §1.5 и §2.2a
- ✅ **wait_session валидация** — добавлена проверка `minutes > 0`, возвращает Error при невалидных значениях
- ✅ **restart_session формат sentinel** — использует `\n` как разделитель между префиксом и reason для однозначного парсинга
- ℹ️ **runner регистрация** — не актуально после merge (upstream удалил `_make_agent`)

## Как воспроизвести (демонстрация)

**Команда:**
```bash
python -c "from atman.adapters.agent.tools import restart_session, wait_session; \
r = restart_session(None,'test'); assert r.startswith('__ATMAN_RESTART_REQUESTED__'); \
w = wait_session(None, 5); assert 'WAIT_REQUESTED' in w; \
e = wait_session(None, -1); assert e.startswith('Error:'); \
print('✓ Tools work correctly with validation')"
```

**Ожидаемый результат:** вывод `✓ Tools work correctly with validation`

**Тесты:**
```bash
pytest tests/test_tools.py::TestRestartSession -v  # 3 tests
pytest tests/test_tools.py::TestWaitSession -v     # 4 tests (включая валидацию)
```

## Тип изменений

- [x] Новая возможность / документация

## Карта системы

- **Затронутые разделы карты:** §1.5 `adapters/agent/tools.py` — добавлены `restart_session`, `wait_session`; §2.2a — обновлено описание интеграций
- **Покрытие тестами:** 
  - `tests/test_tools.py::TestRestartSession` (3 теста)
  - `tests/test_tools.py::TestWaitSession` (4 теста, включая валидацию)
- **Закрытые GAP'ы из §4.5:** N/A
- **Карта обновлена:** ✅ `SYSTEM_MAP.md` и `SYSTEM_MAP-ru.md` обновлены в коммите 9956483

## Тесты-страховки агентной разработки

- [x] `tests/test_cli_all_commands.py` — N/A (инструменты агента, не CLI-команды)
- [x] `tests/test_state_store_contract.py` — N/A (не меняет порт StateStore)
- [x] `tests/test_serialization_roundtrip.py` — N/A (не меняет персистируемые модели)
- [x] `tests/test_golden_schema.py` — N/A (не меняет сериализацию)
- [x] `tests/test_cli_roundtrip.py` — N/A (не меняет формат файла стораджа)
- [x] `tests/test_domain_invariants.py` — N/A (не добавляет бизнес-инварианты)
- [x] `tests/test_e2e_full_cli.py` — N/A (не меняет lifecycle)

## Чеклист

- [x] Описание соответствует фактическим изменениям
- [x] При необходимости обновлены `README` / `docs` / демо-сценарий (N/A — внутренние инструменты агента)
- [x] При необходимости обновлены `docs/architecture/SYSTEM_MAP.md` и `SYSTEM_MAP-ru.md` ✅ (коммит 9956483)
- [x] `ruff check src/ tests/` — 0 ошибок
- [x] `ruff format --check src/ tests/` — 0 ошибок
- [x] `pyright src/atman/adapters/agent/ tests/test_tools.py` — 0 ошибок
- [x] `bandit -c pyproject.toml -r src/atman/` — 0 ошибок
- [x] `pytest tests/test_tools.py -v` — все тесты проходят (14/14)
- [x] Merge conflicts resolved: принята upstream-версия `runner.py`, E22.4 изменения применены к `tools.py` и `__init__.py`
- [x] Devin Review comments addressed (коммит 9956483)

## Примечания

### Разрешение merge conflicts

**Конфликт:** простой, связан с архитектурной реорганизацией upstream
- **Upstream изменения:** функция `_make_agent()` удалена из `runner.py`, файл теперь содержит только обработку сигналов
- **Мои изменения:** добавление инструментов `restart_session` и `wait_session`
- **Разрешение:** принята upstream-версия `runner.py`, инструменты добавлены только в `tools.py` и экспортированы через `__init__.py`

### Исправления по Devin Review (коммит 9956483)

1. **🔴 SYSTEM_MAP не обновлен** → ✅ исправлено
   - Добавлены `restart_session`, `wait_session` в `SYSTEM_MAP.md` §1.5
   - Обновлено описание интеграций в §2.2a
   - Синхронизирована русская версия `SYSTEM_MAP-ru.md`

2. **🟡 wait_session без валидации** → ✅ исправлено
   - Добавлена проверка `minutes > 0`
   - Возвращает `Error: minutes must be positive, got {value}` для невалидных значений
   - Добавлен тест `test_wait_session_invalid_minutes`

3. **🚩 Sentinel format ambiguous** → ✅ улучшено
   - `restart_session` теперь использует newline как разделитель: `__ATMAN_RESTART_REQUESTED__\n{reason}`
   - Обеспечивает однозначный парсинг через проверку префикса
   - Обновлены тесты для проверки нового формата

4. **🚩 Runner registration** → ℹ️ не актуально
   - После merge: `_make_agent()` удалена из `runner.py` upstream
   - Регистрация инструментов будет в другом месте (E22.5)

**Проверки:**
- ✅ Все тесты проходят (14/14)
- ✅ Инструменты корректно импортируются и возвращают ожидаемые sentinel-строки
- ✅ Валидация работает корректно
- ✅ SYSTEM_MAP обновлен
- ✅ Pre-existing psycopg errors в pyright не являются регрессией (см. AGENTS.md Gotchas)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9dd448ab-459c-4f4d-a5a5-2e8bd5cd37c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9dd448ab-459c-4f4d-a5a5-2e8bd5cd37c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

