### PR TITLE
#E22.7 — Close-context injection at session start

### DIFF
--- a/docs/architecture/SYSTEM_MAP-ru.md
+++ b/docs/architecture/SYSTEM_MAP-ru.md
@@ -24,7 +24,7 @@
 | Файл | Назначение | Публичные классы |
 |------|------------|------------------|
 | `core/models/fact.py` | Верифицируемые факты и связи между ними | `FactRecord`, `Relation` |
-| `core/models/experience.py` | Прожитый опыт, ключевые моменты, переосмысление | `SessionExperience`, `KeyMoment`, `FeltSense`, `ContextHalo`, `ReframingNote`, `EmotionalDepth`, `ReframingNoteAppendResult` |
+| `core/models/experience.py` | Прожитый опыт, ключевые моменты, переосмысление, метаданные завершения сессии (E22.7: `close_reason`, `restart_reason`, `agent_recap`) | `SessionExperience`, `KeyMoment`, `FeltSense`, `ContextHalo`, `ReframingNote`, `EmotionalDepth`, `ReframingNoteAppendResult` |
 | `core/models/identity.py` | Самопредставление агента (ценности, привычки, принципы, цели, открытые вопросы) | `Identity`, `CoreValue`, `Habit`, `Principle`, `Goal`, `OpenQuestion`, `IdentitySnapshot`, `HelpfulnessLevel` |
 | `core/models/narrative.py` | Документ самонарратива (CORE/RECENT/THREADS) и собственное состояние | `NarrativeDocument`, `NarrativeLayer`, `NarrativeThread`, `Eigenstate` (`schema_version`, опциональный `identity_id`), `LayerType` |
 | `core/models/session.py` | Модели сессионного runtime: контекст, события, входящий key moment, результат, сводка активных | `SessionContext`, `SessionEvent`, `KeyMomentInput`, `SessionResult`, `ActiveSessionSummary` |
@@ -192,7 +192,7 @@
 | `AtmanDeps` ↔ `SessionManager`, `IdentityService`, `ExperienceService`, `MicroReflectionService`, `StateStore` | `adapters/agent/deps.py` | DI-контейнер (frozen dataclass) |
 | `record_key_moment` / `log_experience` / `restart_session` / `wait_session` ↔ `AffectDetector.submit_self_report` / `SessionManager` | `adapters/agent/tools.py` → `affect/detector.py` + `core/services/session_manager.py` | Async Pydantic AI инструменты → affect write gateway (`record_key_moment` требует `affect_workspace` + config для `SessionManager`; `restart_session` / `wait_session` возвращают sentinel-строки для детекции в E22.5 runner) |
 | `build_instructions` ↔ `StateStore.load_identity` / `load_narrative` | `adapters/agent/instructions.py` → `core/ports/state_store.py` | динамический билдер system-prompt |
-| `chat` / `_force_finish` ↔ `SessionManager` | `adapters/agent/runner.py` → `core/services/session_manager.py` | регистрация signal handler + exception boundary; вызывает `append_key_moment_input()`, `get_active_session()`, `finish_session()` при прерывании (E22.2) |
+| `chat` / `_force_finish` ↔ `SessionManager` | `adapters/agent/runner.py` → `core/services/session_manager.py` | регистрация signal handler + exception boundary; вызывает `append_key_moment_input()`, `get_active_session()`, `finish_session(..., close_reason=...)` при прерывании (E22.2); инжекция wake-up сообщения из `close_reason` последней сессии (E22.7) |
 
 ### 2.3. CLI ↔ сервис
 
@@ -318,7 +318,7 @@ PrincipleRevisionAdvisor — пересмотр принципов
 2. Во время сессии: `record_event(...)` отслеживает сырые события от нижнего агента и при наличии конфигурации планирует **AffectDetector**.
 3. Программные моменты: `append_key_moment_input` / `append_key_moment`; инструмент агента `record_key_moment` → `AffectDetector.submit_self_report(...)` с обязательной эмоциональной окраской (valence/intensity/depth).
 4. Если окраска неполная → флаг `incomplete_coloring=True` (честность об ограничении).
-5. `finish_session(...)` → создаёт `SessionExperience` (`recorded_by="session_manager"`) + `Eigenstate`.
+5. `finish_session(...)` → создаёт `SessionExperience` (`recorded_by="session_manager"`) + `Eigenstate`; принимает опциональные `close_reason`, `restart_reason`, `agent_recap` (E22.7) для wake-up контекста при старте следующей сессии.
 6. Оба сохраняются через `StateStore` (опыт immutable, eigenstate для следующей сессии).
 7. Ключевой инвариант: эмоциональная окраска ОБЯЗАНА быть (от реального переживания) или явно помечена неполной.
 8. `KeyMomentInput.recorded_at` копируется в `KeyMoment.when` для согласованной временной шкалы относительно валидации и `finish`.

--- a/docs/architecture/SYSTEM_MAP.md
+++ b/docs/architecture/SYSTEM_MAP.md
@@ -21,7 +21,7 @@ All paths are absolute relative to the repository root.
 | File | Purpose | Public classes |
 |------|---------|----------------|
 | `core/models/fact.py` | Verifiable facts and links between them | `FactRecord`, `Relation` |
-| `core/models/experience.py` | Lived experience, key moments, reframing | `SessionExperience`, `KeyMoment`, `FeltSense`, `ContextHalo`, `ReframingNote`, `EmotionalDepth`, `ReframingNoteAppendResult` |
+| `core/models/experience.py` | Lived experience, key moments, reframing, session closure metadata (E22.7: `close_reason`, `restart_reason`, `agent_recap`) | `SessionExperience`, `KeyMoment`, `FeltSense`, `ContextHalo`, `ReframingNote`, `EmotionalDepth`, `ReframingNoteAppendResult` |
 | `core/models/identity.py` | Agent's self-representation (values, habits, principles, goals, open questions) | `Identity`, `CoreValue`, `Habit`, `Principle`, `Goal`, `OpenQuestion`, `IdentitySnapshot`, `HelpfulnessLevel` |
 | `core/models/narrative.py` | Self-narrative document (CORE/RECENT/THREADS) and eigenstate | `NarrativeDocument`, `NarrativeLayer`, `NarrativeThread`, `Eigenstate` (`schema_version`, optional `identity_id`), `LayerType` |
 | `core/models/session.py` | Session runtime models: context, events, key moment input, result, active listing | `SessionContext`, `SessionEvent`, `KeyMomentInput`, `SessionResult`, `ActiveSessionSummary` |
@@ -191,7 +191,7 @@ Connections between two or more parts. These are seams that may break independen
 | `AtmanDeps` ↔ `SessionManager`, `IdentityService`, `ExperienceService`, `MicroReflectionService`, `StateStore` | `adapters/agent/deps.py` | DI container (frozen dataclass) |
 | `record_key_moment` / `log_experience` / `restart_session` / `wait_session` ↔ `AffectDetector.submit_self_report` / `SessionManager` | `adapters/agent/tools.py` → `affect/detector.py` + `core/services/session_manager.py` | Async Pydantic AI tools → affect write gateway (`record_key_moment` requires `affect_workspace` + config on `SessionManager`; `restart_session` / `wait_session` return sentinel strings for E22.5 runner detection) |
 | `build_instructions` ↔ `StateStore.load_identity` / `load_narrative` | `adapters/agent/instructions.py` → `core/ports/state_store.py` | dynamic system-prompt builder |
-| `chat` / `_force_finish` ↔ `SessionManager` | `adapters/agent/runner.py` → `core/services/session_manager.py` | Signal handler registration + exception boundary; calls `append_key_moment_input()`, `get_active_session()`, `finish_session()` on interruption (E22.2) |
+| `chat` / `_force_finish` ↔ `SessionManager` | `adapters/agent/runner.py` → `core/services/session_manager.py` | Signal handler registration + exception boundary; calls `append_key_moment_input()`, `get_active_session()`, `finish_session(..., close_reason=...)` on interruption (E22.2); wake-up message injection from last session's `close_reason` (E22.7) |
 
 ### 2.3. CLI ↔ service
 
@@ -317,7 +317,7 @@ Files: `docs/features/session-manager/`, `src/demo_session_manager.py`, `tests/t
 2. During session: `record_event(...)` tracks raw events from lower agent and may schedule **AffectDetector** (optional).
 3. Programmatic moments: `append_key_moment_input(...)` / `append_key_moment(...)`; agent tool `record_key_moment` → `AffectDetector.submit_self_report(...)` with mandatory emotional coloring (valence/intensity/depth).
 4. If coloring incomplete → flag `incomplete_coloring=True` (honest about limitation).
-5. `finish_session(...)` → creates `SessionExperience` (`recorded_by="session_manager"`) + `Eigenstate`.
+5. `finish_session(...)` → creates `SessionExperience` (`recorded_by="session_manager"`) + `Eigenstate`; accepts optional `close_reason`, `restart_reason`, `agent_recap` (E22.7) for wake-up context on next session start.
 6. Both stored via `StateStore` (experience immutable, eigenstate for next session).
 7. Key invariant: emotional coloring MUST be present (from real experiencing) or explicitly marked incomplete.
 8. `KeyMomentInput.recorded_at` is copied to `KeyMoment.when` so timestamps are stable relative to validation/finish ordering.

--- a/src/atman/adapters/agent/runner.py
+++ b/src/atman/adapters/agent/runner.py
@@ -181,7 +181,7 @@ def chat(
 def _force_finish(
     session_manager: SessionManager,
     session_id: UUID,
-    close_reason: str,
+    close_reason: str | None,
 ) -> None:
     """
     Force-finish a session with minimum viable state.
@@ -194,7 +194,7 @@ def _force_finish(
     Args:
         session_manager: Session manager instance
         session_id: UUID of the session to finish
-        close_reason: Reason for forced finish (e.g. "interrupted")
+        close_reason: Reason for forced finish (e.g. "interrupted"), or None for normal completion
 
     Raises:
         SessionNotFoundError: If session is not active
@@ -215,14 +215,21 @@ def _force_finish(
             session_id,
         )
 
-        # Create minimal key moment for interrupted session
+        # Create minimal key moment - text depends on whether this was an interruption
+        if close_reason and close_reason != "completed":
+            what_happened = f"Session interrupted ({close_reason})"
+            why_it_matters = "Session was interrupted before completion"
+        else:
+            what_happened = "Session completed without recorded key moments"
+            why_it_matters = "Session ended normally but no moments were captured"
+
         minimal_moment = KeyMomentInput(
-            what_happened=f"Session interrupted ({close_reason})",
+            what_happened=what_happened,
             recorded_at=datetime.now(UTC),
             emotional_valence=0.0,
-            emotional_intensity=0.3,  # Slight arousal from interruption
+            emotional_intensity=0.3 if close_reason else 0.1,
             depth=EmotionalDepth.SURFACE,
-            why_it_matters="Session was interrupted before completion",
+            why_it_matters=why_it_matters,
             incomplete_coloring=True,  # Honest: this is synthetic
         )
 
@@ -233,16 +240,20 @@ def _force_finish(
             _LOG.warning("Session %s was finished during force-finish", session_id)
             return
 
-    # Finish session with interrupted status
+    # Finish session - only pass close_reason if it's a documented value
+    valid_close_reasons = {"timeout_sleep", "restart", "forced", "interrupted"}
+    finish_kwargs = {
+        "session_id": session_id,
+        "overall_emotional_tone": 0.0,
+        "key_insight": f"Session {close_reason or 'completed'}",
+        "alignment_check": True,
+        "alignment_notes": "",
+    }
+    if close_reason and close_reason in valid_close_reasons:
+        finish_kwargs["close_reason"] = close_reason
+
     try:
-        session_manager.finish_session(
-            session_id,
-            overall_emotional_tone=0.0,
-            key_insight=f"Session {close_reason}",
-            alignment_check=True,
-            alignment_notes="",
-            close_reason=close_reason,
-        )
+        session_manager.finish_session(**finish_kwargs)
         _LOG.info("Session %s force-finished successfully", session_id)
 
     except SessionAlreadyFinishedError:
@@ -273,6 +284,7 @@ class AtmanRunner:
 
         deps, session_manager, _store = build_deps(self._workspace, self._agent_id, self._config)
         session_id: UUID | None = None
+        interrupted = False  # Track if session was interrupted
         try:
             session_ctx = session_manager.start_session(self._agent_id)
             session_id = session_ctx.session_id
@@ -331,19 +343,27 @@ class AtmanRunner:
                 print_plain("")
         except KeyboardInterrupt:
             print_warn("\nInterrupted.")
+            # Track interruption for close_reason
+            interrupted = True
         finally:
             if session_id is not None:
                 try:
-                    session_manager.finish_session(
-                        session_id,
-                        overall_emotional_tone=0.0,
-                        key_insight="",
-                        alignment_check=True,
-                        alignment_notes="",
-                    )
+                    # Pass close_reason if session was interrupted
+                    finish_kwargs = {
+                        "session_id": session_id,
+                        "overall_emotional_tone": 0.0,
+                        "key_insight": "",
+                        "alignment_check": True,
+                        "alignment_notes": "",
+                    }
+                    if interrupted:
+                        finish_kwargs["close_reason"] = "interrupted"
+
+                    session_manager.finish_session(**finish_kwargs)
                 except ValueError as exc:
                     if "Cannot finish session without key moments" in str(exc):
-                        _force_finish(session_manager, session_id, "completed")
+                        # Pass None for normal completion without key moments
+                        _force_finish(session_manager, session_id, None)
                     else:
                         raise
                 except (SessionAlreadyFinishedError, SessionNotFoundError):

--- a/src/atman/adapters/agent/runner.py
+++ b/src/atman/adapters/agent/runner.py
@@ -241,6 +241,7 @@ def _force_finish(
             key_insight=f"Session {close_reason}",
             alignment_check=True,
             alignment_notes="",
+            close_reason=close_reason,
         )
         _LOG.info("Session %s force-finished successfully", session_id)
 
@@ -319,12 +320,13 @@ class AtmanRunner:
                         deps=deps,
                         message_history=message_history if message_history else None,
                     )
-                    # Only use history once for wake-up message
-                    if message_history:
-                        message_history = []
                 except Exception as exc:
                     print_err(f"Run failed: {exc!s}")
                     continue
+                finally:
+                    # Clear wake-up message after first run attempt (success or failure)
+                    if message_history:
+                        message_history = []
                 print_plain(str(result.output))
                 print_plain("")
         except KeyboardInterrupt:

--- a/src/atman/adapters/agent/runner.py
+++ b/src/atman/adapters/agent/runner.py
@@ -263,6 +263,8 @@ class AtmanRunner:
 
     async def chat(self) -> None:
         """Run a simple stdin/stdout chat loop until EOF, empty input, or Ctrl-C."""
+        from pydantic_ai.messages import ModelRequest, UserPromptPart
+
         from atman.adapters.agent.factory import build_deps
         from atman.adapters.agent.instructions import build_instructions
         from atman.adapters.agent.tools import log_experience, record_key_moment
@@ -287,6 +289,22 @@ class AtmanRunner:
                 tools=tool_funcs,
             )
 
+            # E22.7: Inject wake-up message if previous session had close_reason
+            message_history: list[ModelRequest] = []
+            recent_experiences = session_manager._state_store.list_recent_experiences(limit=1)
+            if recent_experiences:
+                last_experience = recent_experiences[0].experience
+                wake_up_msg = self._build_wake_up_message(last_experience)
+                if wake_up_msg:
+                    _LOG.info("Injecting wake-up message for session %s", session_id)
+                    message_history.append(
+                        ModelRequest(
+                            parts=[
+                                UserPromptPart(content=f"[SYSTEM] {wake_up_msg}"),
+                            ],
+                        )
+                    )
+
             print_info("Session started. Empty line or Ctrl-D to exit.\n")
             while True:
                 try:
@@ -296,7 +314,14 @@ class AtmanRunner:
                 if not user_text.strip():
                     break
                 try:
-                    result = await agent.run(user_text, deps=deps)
+                    result = await agent.run(
+                        user_text,
+                        deps=deps,
+                        message_history=message_history if message_history else None,
+                    )
+                    # Only use history once for wake-up message
+                    if message_history:
+                        message_history = []
                 except Exception as exc:
                     print_err(f"Run failed: {exc!s}")
                     continue
@@ -321,3 +346,27 @@ class AtmanRunner:
                         raise
                 except (SessionAlreadyFinishedError, SessionNotFoundError):
                     pass
+
+    def _build_wake_up_message(self, experience: object) -> str | None:
+        """Build wake-up message based on close_reason from last SessionExperience."""
+        from atman.core.models import SessionExperience
+
+        if not isinstance(experience, SessionExperience):
+            return None
+
+        close_reason = experience.close_reason
+        if not close_reason:
+            return None
+
+        if close_reason == "timeout_sleep":
+            recap = experience.agent_recap or "нет recap"
+            return f"Ты задремал — пользователь отошёл, ты решил поспать. {recap}"
+        elif close_reason == "restart":
+            reason = experience.restart_reason or "не указана"
+            return f"Ты сам инициировал перезапуск. Причина: {reason}"
+        elif close_reason == "forced":
+            return "Контекст переполнился принудительно — ты не успел завершить сессию осознанно."
+        elif close_reason == "interrupted":
+            return "Сессия была прервана внешним сигналом — ты не участвовал в закрытии."
+
+        return None

--- a/src/atman/core/models/experience.py
+++ b/src/atman/core/models/experience.py
@@ -287,6 +287,20 @@ class SessionExperience(BaseModel):
         description="IDs of all facts accessed during this session (deduplicated)",
     )
 
+    # SESSION CLOSURE METADATA (E22.7)
+    close_reason: str | None = Field(
+        default=None,
+        description="Reason for session closure: timeout_sleep | restart | forced | interrupted | None",
+    )
+    restart_reason: str | None = Field(
+        default=None,
+        description="Human-readable reason when close_reason=restart (agent's own words)",
+    )
+    agent_recap: str | None = Field(
+        default=None,
+        description="Agent's recap before timeout_sleep (optional, agent-authored)",
+    )
+
     @field_validator("importance", "salience")
     @classmethod
     def validate_zero_to_one(cls, v: float) -> float:

--- a/src/atman/core/services/session_manager.py
+++ b/src/atman/core/services/session_manager.py
@@ -338,6 +338,9 @@ class SessionManager:
         key_insight: str = "",
         alignment_check: bool = True,
         alignment_notes: str = "",
+        close_reason: str | None = None,
+        restart_reason: str | None = None,
+        agent_recap: str | None = None,
     ) -> SessionResult:
         """
         Finish session and create SessionExperience + Eigenstate + update Narrative.
@@ -361,6 +364,9 @@ class SessionManager:
             key_insight: Main insight from session
             alignment_check: Did experience match identity?
             alignment_notes: Notes about alignment or drift
+            close_reason: Reason for session closure (timeout_sleep | restart | forced | interrupted)
+            restart_reason: Human-readable reason when close_reason=restart
+            agent_recap: Agent's recap before timeout_sleep
 
         Returns:
             SessionResult: Complete session result with experience and eigenstate
@@ -420,6 +426,9 @@ class SessionManager:
                     salience=0.5,
                     incomplete_coloring=session_result.incomplete_coloring,
                     fact_refs=list(fact_refs_set),
+                    close_reason=close_reason,
+                    restart_reason=restart_reason,
+                    agent_recap=agent_recap,
                 )
                 experience_record = ExperienceRecord(experience=experience)
                 self._state_store.create_experience(experience_record)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -93,13 +93,18 @@ def test_force_finish_creates_minimal_key_moment(
     assert session_result is not None
     assert len(session_result.key_moments) == 0
 
-    # Force finish
-    _force_finish(session_manager, ctx.session_id, close_reason="test_interrupted")
+    # Force finish with invalid close_reason should not persist it
+    _force_finish(session_manager, ctx.session_id, close_reason="test_invalid")
 
     # Verify session was finished and has exactly one minimal key moment
     # Session should no longer be active
     session_result_after = session_manager.get_active_session(ctx.session_id)
     assert session_result_after is None
+
+    # Verify close_reason was NOT persisted (invalid value)
+    experiences = session_manager._state_store.list_recent_experiences(limit=1)
+    assert len(experiences) == 1
+    assert experiences[0].experience.close_reason is None
 
 
 def test_force_finish_with_existing_key_moments(
@@ -120,8 +125,8 @@ def test_force_finish_with_existing_key_moments(
     )
     session_manager.append_key_moment_input(ctx.session_id, moment)
 
-    # Force finish
-    _force_finish(session_manager, ctx.session_id, close_reason="test_interrupted")
+    # Force finish with valid close_reason
+    _force_finish(session_manager, ctx.session_id, close_reason="interrupted")
 
     # Session should no longer be active (finished)
     session_result = session_manager.get_active_session(ctx.session_id)
@@ -372,7 +377,7 @@ def test_force_finish_incomplete_coloring_flag(
     assert len(session_result.key_moments) == 0
 
     # Force finish should create minimal moment with incomplete_coloring=True
-    _force_finish(session_manager, ctx.session_id, close_reason="test")
+    _force_finish(session_manager, ctx.session_id, close_reason=None)
 
     # Session should be finished (no longer active)
     session_result_after = session_manager.get_active_session(ctx.session_id)
@@ -556,7 +561,7 @@ def test_force_finish_persists_close_reason(
     session_manager: SessionManager,
     identity_with_narrative: Identity,
 ) -> None:
-    """Test that _force_finish persists close_reason to SessionExperience."""
+    """Test that _force_finish persists close_reason to SessionExperience for valid values."""
     ctx = session_manager.start_session(identity_with_narrative.id)
     moment = KeyMomentInput(
         what_happened="Some work",
@@ -574,3 +579,27 @@ def test_force_finish_persists_close_reason(
     experiences = session_manager._state_store.list_recent_experiences(limit=1)
     assert len(experiences) == 1
     assert experiences[0].experience.close_reason == "interrupted"
+
+
+def test_force_finish_none_close_reason_for_normal_completion(
+    session_manager: SessionManager,
+    identity_with_narrative: Identity,
+) -> None:
+    """Test that _force_finish with None close_reason doesn't persist close_reason field."""
+    ctx = session_manager.start_session(identity_with_narrative.id)
+    moment = KeyMomentInput(
+        what_happened="Normal work",
+        emotional_valence=0.0,
+        emotional_intensity=0.3,
+        depth=EmotionalDepth.SURFACE,
+        why_it_matters="Regular session",
+    )
+    session_manager.append_key_moment_input(ctx.session_id, moment)
+
+    # Force finish with None (normal completion, no interruption)
+    _force_finish(session_manager, ctx.session_id, close_reason=None)
+
+    # Verify SessionExperience has close_reason=None
+    experiences = session_manager._state_store.list_recent_experiences(limit=1)
+    assert len(experiences) == 1
+    assert experiences[0].experience.close_reason is None

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -377,3 +377,176 @@ def test_force_finish_incomplete_coloring_flag(
     # Session should be finished (no longer active)
     session_result_after = session_manager.get_active_session(ctx.session_id)
     assert session_result_after is None
+
+
+def test_build_wake_up_message_timeout_sleep(
+    session_manager: SessionManager,
+    identity_with_narrative: Identity,
+) -> None:
+    """Test wake-up message for timeout_sleep close_reason."""
+    from atman.adapters.agent.config import AgentConfig, ModelConfig
+    from atman.adapters.agent.runner import AtmanRunner
+
+    ctx = session_manager.start_session(identity_with_narrative.id)
+    moment = KeyMomentInput(
+        what_happened="User went away",
+        emotional_valence=0.0,
+        emotional_intensity=0.3,
+        depth=EmotionalDepth.SURFACE,
+        why_it_matters="Timeout",
+    )
+    session_manager.append_key_moment_input(ctx.session_id, moment)
+    session_manager.finish_session(
+        ctx.session_id,
+        close_reason="timeout_sleep",
+        agent_recap="Пользователь обсуждал проект X",
+    )
+
+    # Get last experience and build wake-up message
+    experiences = session_manager._state_store.list_recent_experiences(limit=1)
+    assert len(experiences) == 1
+    last_exp = experiences[0].experience
+
+    runner = AtmanRunner(
+        workspace=Path("/tmp"),
+        agent_id=identity_with_narrative.id,
+        config=AgentConfig(model=ModelConfig(model="test")),
+    )
+    msg = runner._build_wake_up_message(last_exp)
+    assert msg is not None
+    assert "задремал" in msg
+    assert "Пользователь обсуждал проект X" in msg
+
+
+def test_build_wake_up_message_restart(
+    session_manager: SessionManager,
+    identity_with_narrative: Identity,
+) -> None:
+    """Test wake-up message for restart close_reason."""
+    from atman.adapters.agent.config import AgentConfig, ModelConfig
+    from atman.adapters.agent.runner import AtmanRunner
+
+    ctx = session_manager.start_session(identity_with_narrative.id)
+    moment = KeyMomentInput(
+        what_happened="Agent initiated restart",
+        emotional_valence=0.0,
+        emotional_intensity=0.4,
+        depth=EmotionalDepth.SURFACE,
+        why_it_matters="Restart needed",
+    )
+    session_manager.append_key_moment_input(ctx.session_id, moment)
+    session_manager.finish_session(
+        ctx.session_id,
+        close_reason="restart",
+        restart_reason="Контекст заполнен, продолжу с чистой историей",
+    )
+
+    experiences = session_manager._state_store.list_recent_experiences(limit=1)
+    last_exp = experiences[0].experience
+
+    runner = AtmanRunner(
+        workspace=Path("/tmp"),
+        agent_id=identity_with_narrative.id,
+        config=AgentConfig(model=ModelConfig(model="test")),
+    )
+    msg = runner._build_wake_up_message(last_exp)
+    assert msg is not None
+    assert "перезапуск" in msg
+    assert "Контекст заполнен, продолжу с чистой историей" in msg
+
+
+def test_build_wake_up_message_forced(
+    session_manager: SessionManager,
+    identity_with_narrative: Identity,
+) -> None:
+    """Test wake-up message for forced close_reason."""
+    from atman.adapters.agent.config import AgentConfig, ModelConfig
+    from atman.adapters.agent.runner import AtmanRunner
+
+    ctx = session_manager.start_session(identity_with_narrative.id)
+    moment = KeyMomentInput(
+        what_happened="Context overflow",
+        emotional_valence=0.0,
+        emotional_intensity=0.5,
+        depth=EmotionalDepth.SURFACE,
+        why_it_matters="Forced closure",
+    )
+    session_manager.append_key_moment_input(ctx.session_id, moment)
+    session_manager.finish_session(ctx.session_id, close_reason="forced")
+
+    experiences = session_manager._state_store.list_recent_experiences(limit=1)
+    last_exp = experiences[0].experience
+
+    runner = AtmanRunner(
+        workspace=Path("/tmp"),
+        agent_id=identity_with_narrative.id,
+        config=AgentConfig(model=ModelConfig(model="test")),
+    )
+    msg = runner._build_wake_up_message(last_exp)
+    assert msg is not None
+    assert "переполнился" in msg
+    assert "осознанно" in msg
+
+
+def test_build_wake_up_message_interrupted(
+    session_manager: SessionManager,
+    identity_with_narrative: Identity,
+) -> None:
+    """Test wake-up message for interrupted close_reason."""
+    from atman.adapters.agent.config import AgentConfig, ModelConfig
+    from atman.adapters.agent.runner import AtmanRunner
+
+    ctx = session_manager.start_session(identity_with_narrative.id)
+    moment = KeyMomentInput(
+        what_happened="Signal received",
+        emotional_valence=0.0,
+        emotional_intensity=0.4,
+        depth=EmotionalDepth.SURFACE,
+        why_it_matters="Interrupted",
+    )
+    session_manager.append_key_moment_input(ctx.session_id, moment)
+    session_manager.finish_session(ctx.session_id, close_reason="interrupted")
+
+    experiences = session_manager._state_store.list_recent_experiences(limit=1)
+    last_exp = experiences[0].experience
+
+    runner = AtmanRunner(
+        workspace=Path("/tmp"),
+        agent_id=identity_with_narrative.id,
+        config=AgentConfig(model=ModelConfig(model="test")),
+    )
+    msg = runner._build_wake_up_message(last_exp)
+    assert msg is not None
+    assert "прервана" in msg
+    assert "внешним сигналом" in msg
+
+
+def test_build_wake_up_message_no_close_reason(
+    session_manager: SessionManager,
+    identity_with_narrative: Identity,
+) -> None:
+    """Test that no wake-up message is generated when close_reason is None."""
+    from atman.adapters.agent.config import AgentConfig, ModelConfig
+    from atman.adapters.agent.runner import AtmanRunner
+
+    ctx = session_manager.start_session(identity_with_narrative.id)
+    moment = KeyMomentInput(
+        what_happened="Normal completion",
+        emotional_valence=0.0,
+        emotional_intensity=0.3,
+        depth=EmotionalDepth.SURFACE,
+        why_it_matters="Session done",
+    )
+    session_manager.append_key_moment_input(ctx.session_id, moment)
+    session_manager.finish_session(ctx.session_id)
+
+    experiences = session_manager._state_store.list_recent_experiences(limit=1)
+    last_exp = experiences[0].experience
+
+    runner = AtmanRunner(
+        workspace=Path("/tmp"),
+        agent_id=identity_with_narrative.id,
+        config=AgentConfig(model=ModelConfig(model="test")),
+    )
+    msg = runner._build_wake_up_message(last_exp)
+    assert msg is None

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -550,3 +550,27 @@ def test_build_wake_up_message_no_close_reason(
     )
     msg = runner._build_wake_up_message(last_exp)
     assert msg is None
+
+
+def test_force_finish_persists_close_reason(
+    session_manager: SessionManager,
+    identity_with_narrative: Identity,
+) -> None:
+    """Test that _force_finish persists close_reason to SessionExperience."""
+    ctx = session_manager.start_session(identity_with_narrative.id)
+    moment = KeyMomentInput(
+        what_happened="Some work",
+        emotional_valence=0.0,
+        emotional_intensity=0.4,
+        depth=EmotionalDepth.SURFACE,
+        why_it_matters="Task in progress",
+    )
+    session_manager.append_key_moment_input(ctx.session_id, moment)
+
+    # Force finish with specific close_reason
+    _force_finish(session_manager, ctx.session_id, close_reason="interrupted")
+
+    # Verify SessionExperience has the close_reason
+    experiences = session_manager._state_store.list_recent_experiences(limit=1)
+    assert len(experiences) == 1
+    assert experiences[0].experience.close_reason == "interrupted"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### #E22.7 — Close-context injection at session start

**Type:** subtask | **Labels:** session-manager, M2-internal-G, cursor-ready | **Effort:** 3h

#### Summary

Implemented close-context injection at session start, allowing the agent to be aware of how the previous session ended. At the start of `chat()`, before the first `agent.run()`, the system now fetches the last `SessionExperience` and prepends a wake-up message to the conversation history based on the `close_reason`.

#### Changes Made

1. **SessionExperience Model** (`src/atman/core/models/experience.py`)
   - Added `close_reason: str | None` field (timeout_sleep | restart | forced | interrupted)
   - Added `restart_reason: str | None` field (agent's explanation when close_reason=restart)
   - Added `agent_recap: str | None` field (agent's recap before timeout_sleep)

2. **SessionManager** (`src/atman/core/services/session_manager.py`)
   - Updated `finish_session()` signature to accept `close_reason`, `restart_reason`, `agent_recap`
   - Updated `SessionExperience` creation to persist these new fields

3. **AgentRunner** (`src/atman/adapters/agent/runner.py`)
   - Implemented wake-up message injection in `AtmanRunner.chat()`
   - Added `_build_wake_up_message()` method that constructs context-specific wake-up messages:
     - **timeout_sleep**: "Ты задремал — пользователь отошёл, ты решил поспать. {agent_recap}"
     - **restart**: "Ты сам инициировал перезапуск. Причина: {restart_reason}"
     - **forced**: "Контекст переполнился принудительно — ты не успел завершить сессию осознанно."
     - **interrupted**: "Сессия была прервана внешним сигналом — ты не участвовал в закрытии."
   - Fetches last `SessionExperience` once at process startup
   - Injects wake-up message as `ModelRequest` with `UserPromptPart`
   - **Fixed**: `_force_finish` now passes `close_reason` to `finish_session` (critical bug fix)
   - **Fixed**: Wake-up message cleared in `finally` block to prevent re-injection on error

4. **Tests** (`tests/test_runner.py`)
   - Added 7 new tests for wake-up message generation and close_reason persistence:
     - `test_build_wake_up_message_timeout_sleep`
     - `test_build_wake_up_message_restart`
     - `test_build_wake_up_message_forced`
     - `test_build_wake_up_message_interrupted`
     - `test_build_wake_up_message_no_close_reason`
     - `test_force_finish_persists_close_reason` (verifies critical bug fix)
     - `test_force_finish_none_close_reason_for_normal_completion`
   - All tests pass, coverage ≥90%

5. **Documentation** (`docs/architecture/SYSTEM_MAP.md`, `SYSTEM_MAP-ru.md`)
   - Updated `SessionExperience` description to mention E22.7 closure metadata fields
   - Updated `finish_session` description to mention new optional parameters
   - Updated `chat` / `_force_finish` integration description to mention wake-up injection
   - **Merged with main**: Integrated TokenMonitor (E22.3) documentation additions

#### Validation

```bash
pytest tests/test_runner.py -v                               # ✅ 16/16 passed
pytest tests/ -v --cov=atman --cov-fail-under=90             # ✅ 90%+ coverage
ruff check src/ tests/ && ruff format --check src/ tests/    # ✅ All checks passed
pyright src/ tests/                                           # ✅ 0 errors
bandit -c pyproject.toml -r src/atman/                        # ✅ No issues
```

#### Devin Review Fixes

**Round 1 (commit `fea6f6a`)**: All initial Devin Review findings addressed

1. **🔴 Critical Bug Fixed**: `_force_finish` now passes `close_reason` to `finish_session()`
2. **🚩 SYSTEM_MAP.md Updated**: Both versions document E22.7 changes
3. **🚩 Wake-up Message Re-injection Fixed**: Message history cleared in `finally` block

**Round 2 (commit `[current]`)**: New Devin Review findings addressed

1. **🟡 Contract Violation Fixed**: `_force_finish("completed")` persisted undocumented value
   - Changed `_force_finish` signature to accept `str | None`
   - Only pass `close_reason` to `finish_session` for documented values: `timeout_sleep`, `restart`, `forced`, `interrupted`
   - Invalid/undocumented values (including `"completed"`) now result in `close_reason=None`
   - Conditional key moment text: "Session interrupted (reason)" vs "Session completed without recorded key moments"

2. **🚩 KeyboardInterrupt Handling Fixed**: AtmanRunner didn't set close_reason on Ctrl-C
   - Added `interrupted` flag tracking in `AtmanRunner.chat()`
   - Pass `close_reason="interrupted"` when KeyboardInterrupt occurs
   - Ensures interrupted REPL sessions generate wake-up messages on next startup

#### Merge with Main (commit `a9b8d39`)

**Conflicts resolved**: Simple documentation conflicts in `SYSTEM_MAP.md` and `SYSTEM_MAP-ru.md`

- **Conflicting changes**: Both branches modified the `chat`/`_force_finish` integration description
  - **Our branch (E22.7)**: Added wake-up message injection documentation
  - **Main branch (E22.3)**: Added TokenMonitor integration row
- **Resolution**: Combined both changes - kept E22.7 wake-up message updates to the `chat` line and added the new TokenMonitor row from main
- **Classification**: Simple conflict - no conflicting intents, just adjacent documentation additions
- **Verification**: All tests pass after merge ✅

#### Implementation Notes

- Wake-up message is injected **only once per new process startup**, not on every `start_session` call
- Logic remains in `runner.py` as specified (not moved to `SessionManager`)
- Uses `list_recent_experiences(limit=1)` to fetch the last session
- Leverages `pydantic_ai`'s `ModelRequest` + `UserPromptPart` for message history injection
- **Contract enforcement**: Only documented `close_reason` values are persisted; invalid values result in `None`

#### Out of Scope

- Moving logic into SessionManager (runner owns history)
- Injecting on every start_session (only once per process startup)

#### Definition of Done

✅ All acceptance criteria met:
- Close-context fields added to SessionExperience
- finish_session accepts and persists new fields
- Wake-up message injection implemented
- All wake-up message variants tested
- _force_finish correctly forwards close_reason (bug fix)
- close_reason contract enforced (only documented values)
- KeyboardInterrupt sets close_reason (bug fix)
- SYSTEM_MAP updated for both languages
- Merged with main branch (simple conflicts resolved)
- Validation checks pass
- Linked to #E22
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6243dcb-c6be-4fd6-b19f-5b75a085232b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6243dcb-c6be-4fd6-b19f-5b75a085232b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

