### PR TITLE
Postgres key moments adapter

### DIFF
--- a/docs/architecture/SYSTEM_MAP-ru.md
+++ b/docs/architecture/SYSTEM_MAP-ru.md
@@ -98,6 +98,7 @@
 | `adapters/storage/in_memory_state_store.py` (`InMemoryStateStore`) | `StateStore` | полная реализация в памяти с deep copies (опыт + identity + нарратив + eigenstate + словарь ключевых моментов) |
 | `adapters/storage/file_state_store.py` (`FileStateStore`) | `StateStore` | JSON-файлы (опыт + identity + нарратив + eigenstate) + `key_moments.jsonl` (append-only JSONL с восстановлением после повреждений) |
 | `adapters/storage/in_memory_reflection_store.py` | `PatternStore`, `ReflectionEventStore`, `HealthAssessmentStore` | хранилища выводов рефлексии |
+|| **`adapters/state/postgres_state_store.py`** (`PostgresStateStore`) | **`StateStore`** | **Реализация PostgreSQL** (только операции KeyMoment, psycopg3; другие методы StateStore выбрасывают `NotImplementedError`) |
 | **`adapters/storage/in_memory_postgres_reflection_store.py`** (`InMemoryReflectionStore`) | **`ReflectionStore`** | **E27**: в памяти с симуляцией BIGSERIAL + RLS |
 | `adapters/storage/reflection_persistence_helper.py` | — | **E27**: функции-помощники для персистенса рефлексий (`persist_micro_reflection`, `persist_daily_reflection`, `persist_deep_reflection`) |
 | `adapters/reflection/mock_reflection_model.py` (`MockReflectionModel`) | `ReflectionModel` | детерминированный мок |
@@ -179,7 +180,7 @@
 | Адаптер | Реализует |
 |---------|-----------|
 | `InMemoryBackend`, `FileBackend`, `PostgresFactualMemory` | `FactualMemory` |
-| `InMemoryExperienceStore`, `JsonlExperienceStore`, `FileStateStore` | `StateStore` |
+| `InMemoryExperienceStore`, `JsonlExperienceStore`, `FileStateStore`, `PostgresStateStore` | `StateStore` |
 | `MockReflectionModel` | `ReflectionModel` |
 | `InMemoryPatternStore`, `InMemoryReflectionEventStore`, `InMemoryHealthAssessmentStore` | соответствующие порты |
 | **`InMemoryReflectionStore`** | **`ReflectionStore`** (E27) |

--- a/docs/architecture/SYSTEM_MAP.md
+++ b/docs/architecture/SYSTEM_MAP.md
@@ -94,6 +94,7 @@ All paths are absolute relative to the repository root.
 | `adapters/storage/in_memory_state_store.py` (`InMemoryStateStore`) | `StateStore` | full in-memory implementation with deep copies (experience + identity + narrative + eigenstate + key moments dict) |
 | `adapters/storage/file_state_store.py` (`FileStateStore`) | `StateStore` | JSON files (experience + identity + narrative + eigenstate) + `key_moments.jsonl` (append-only JSONL with corruption recovery) |
 | `adapters/storage/in_memory_reflection_store.py` | `PatternStore`, `ReflectionEventStore`, `HealthAssessmentStore` | reflection output stores |
+|| **`adapters/state/postgres_state_store.py`** (`PostgresStateStore`) | **`StateStore`** | **PostgreSQL implementation** (KeyMoment operations only, psycopg3; other StateStore methods raise `NotImplementedError`) |
 | **`adapters/storage/in_memory_postgres_reflection_store.py`** (`InMemoryReflectionStore`) | **`ReflectionStore`** | **E27**: in-memory with BIGSERIAL + RLS simulation |
 | `adapters/storage/reflection_persistence_helper.py` | — | **E27**: helper functions for persisting reflections (`persist_micro_reflection`, `persist_daily_reflection`, `persist_deep_reflection`) |
 | `adapters/reflection/mock_reflection_model.py` (`MockReflectionModel`) | `ReflectionModel` | deterministic mock |
@@ -178,7 +179,7 @@ Connections between two or more parts. These are seams that may break independen
 | Adapter | Implements |
 |---------|------------|
 | `InMemoryBackend`, `FileBackend`, `PostgresFactualMemory` | `FactualMemory` |
-| `InMemoryExperienceStore`, `JsonlExperienceStore`, `FileStateStore` | `StateStore` |
+| `InMemoryExperienceStore`, `JsonlExperienceStore`, `FileStateStore`, `PostgresStateStore` | `StateStore` |
 | `MockReflectionModel` | `ReflectionModel` |
 | `InMemoryPatternStore`, `InMemoryReflectionEventStore`, `InMemoryHealthAssessmentStore` | corresponding ports |
 | `MockEmbeddingAdapter`, `BM25EmbeddingAdapter`, `OllamaEmbeddingAdapter` | `EmbeddingPort` |

--- a/migrations/versions/0005_add_key_moments_table.sql
+++ b/migrations/versions/0005_add_key_moments_table.sql
@@ -1,0 +1,23 @@
+-- Migration 0005: Add key_moments table for KeyMoment adapter
+--
+-- This migration adds the key_moments table to support storing KeyMoment records
+-- independently of experiences. This is additive and idempotent.
+--
+-- Note: This creates a simplified key_moments table in public schema for
+-- the PostgresStateStore adapter. Migration 0004 already created per-agent
+-- key_moments tables with full schema inside agent_N schemas.
+--
+-- Usage:
+--   psql -d atman -f migrations/versions/0005_add_key_moments_table.sql
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS public.key_moments CASCADE;
+
+CREATE TABLE IF NOT EXISTS public.key_moments (
+    id UUID PRIMARY KEY,
+    session_id UUID NOT NULL,
+    data JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS key_moments_session_idx ON public.key_moments(session_id);

--- a/src/atman/adapters/state/__init__.py
+++ b/src/atman/adapters/state/__init__.py
@@ -1,0 +1,5 @@
+"""State storage adapters."""
+
+from atman.adapters.state.postgres_state_store import PostgresStateStore
+
+__all__ = ["PostgresStateStore"]

--- a/src/atman/adapters/state/postgres_state_store.py
+++ b/src/atman/adapters/state/postgres_state_store.py
@@ -122,17 +122,17 @@ class PostgresStateStore(StateStore):
             return
 
         conn = self._get_conn()
-        with conn.cursor() as cur:
+        with conn.transaction(), conn.cursor() as cur:
             for moment in moments:
                 # Serialize the KeyMoment to JSON
                 data = json.dumps(moment.model_dump(mode="json"))
 
                 cur.execute(
                     """
-                    INSERT INTO public.key_moments (id, session_id, data, created_at)
-                    VALUES (%(id)s, %(session_id)s, %(data)s, %(created_at)s)
-                    ON CONFLICT (id) DO NOTHING
-                    """,
+                        INSERT INTO public.key_moments (id, session_id, data, created_at)
+                        VALUES (%(id)s, %(session_id)s, %(data)s, %(created_at)s)
+                        ON CONFLICT (id) DO NOTHING
+                        """,
                     {
                         "id": moment.id,
                         "session_id": session_id,
@@ -140,7 +140,6 @@ class PostgresStateStore(StateStore):
                         "created_at": moment.when,
                     },
                 )
-            conn.commit()
 
     def get_key_moment(self, moment_id: UUID) -> KeyMoment | None:
         """
@@ -294,24 +293,17 @@ class PostgresStateStore(StateStore):
             ValueError: If the key moment already exists
         """
         conn = self._get_conn()
-        with conn.cursor() as cur:
-            # Check if moment already exists
-            cur.execute(
-                "SELECT id FROM public.key_moments WHERE id = %(id)s",
-                {"id": key_moment.id},
-            )
-            if cur.fetchone() is not None:
-                raise ValueError(f"KeyMoment {key_moment.id} already exists")
-
+        with conn.transaction(), conn.cursor() as cur:
             # Note: We don't have session_id in KeyMoment model, so we use a placeholder
             # This method may need review when session_id is added to KeyMoment
             data = json.dumps(key_moment.model_dump(mode="json"))
 
             cur.execute(
                 """
-                INSERT INTO public.key_moments (id, session_id, data, created_at)
-                VALUES (%(id)s, %(session_id)s, %(data)s, %(created_at)s)
-                """,
+                    INSERT INTO public.key_moments (id, session_id, data, created_at)
+                    VALUES (%(id)s, %(session_id)s, %(data)s, %(created_at)s)
+                    ON CONFLICT (id) DO NOTHING
+                    """,
                 {
                     "id": key_moment.id,
                     "session_id": "00000000-0000-0000-0000-000000000000",  # Placeholder
@@ -319,7 +311,10 @@ class PostgresStateStore(StateStore):
                     "created_at": key_moment.when,
                 },
             )
-            conn.commit()
+
+            # Check if the insert was successful (rowcount == 0 means duplicate)
+            if cur.rowcount == 0:
+                raise ValueError(f"KeyMoment {key_moment.id} already exists")
 
         return key_moment
 

--- a/src/atman/adapters/state/postgres_state_store.py
+++ b/src/atman/adapters/state/postgres_state_store.py
@@ -1,0 +1,349 @@
+"""
+PostgreSQL adapter for StateStore (KeyMoment operations only).
+
+Implements KeyMoment storage methods of the StateStore port using psycopg3.
+This is a partial implementation focusing on KeyMoment persistence.
+
+Other StateStore methods (experiences, identity, narrative, eigenstate) are
+not implemented and will raise NotImplementedError.
+"""
+
+import json
+import os
+import warnings
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+if TYPE_CHECKING:
+    import psycopg
+    from psycopg.rows import dict_row
+    from psycopg.types.json import Jsonb
+else:
+    try:
+        import psycopg
+        from psycopg.rows import dict_row
+        from psycopg.types.json import Jsonb
+    except ImportError:
+        psycopg = None
+        dict_row = None  # type: ignore[assignment]
+        Jsonb = None
+        warnings.warn(
+            "psycopg not installed. PostgresStateStore requires PostgreSQL support. "
+            "Install with: pip install 'psycopg[binary]'",
+            ImportWarning,
+            stacklevel=2,
+        )
+
+from atman.core.models import (
+    Eigenstate,
+    ExperienceRecord,
+    Identity,
+    IdentitySnapshot,
+    KeyMoment,
+    NarrativeDocument,
+    ReframingNote,
+)
+from atman.core.ports.state_store import (
+    ExperienceQuery,
+    StateStore,
+)
+
+
+def _parse_key_moment(row: Any) -> KeyMoment:
+    """Build a KeyMoment from a psycopg row."""
+    data = row["data"]
+    if isinstance(data, str):
+        data = json.loads(data)
+
+    # Parse the JSON data into a KeyMoment model
+    return KeyMoment.model_validate(data)
+
+
+class PostgresStateStore(StateStore):
+    """
+    PostgreSQL implementation of StateStore (KeyMoment operations only).
+
+    Reads database URL from (in order):
+      1. ``db_url`` constructor argument
+      2. ``ATMAN_DB_URL`` environment variable
+      3. ``DATABASE_URL`` environment variable
+      4. ``postgresql://atman@localhost:5432/atman`` (default)
+
+    Example::
+
+        store = PostgresStateStore()
+        store.store_key_moments(session_id, [moment1, moment2])
+        moments = store.get_key_moments_for_session(session_id)
+    """
+
+    def __init__(self, db_url: str | None = None) -> None:
+        if psycopg is None:
+            raise ImportError("psycopg not installed. Install with: pip install 'psycopg[binary]'")
+
+        self._db_url = (
+            db_url
+            or os.environ.get("ATMAN_DB_URL")
+            or os.environ.get("DATABASE_URL")
+            or "postgresql://atman@localhost:5432/atman"
+        )
+        self._conn: psycopg.Connection[Any] | None = None
+
+    def _get_conn(self) -> "psycopg.Connection[Any]":
+        """Get or create database connection."""
+        if self._conn is None or self._conn.closed:
+            self._conn = psycopg.connect(self._db_url, row_factory=dict_row)  # type: ignore[arg-type]
+        return self._conn
+
+    def close(self) -> None:
+        """Close database connection."""
+        if self._conn is not None and not self._conn.closed:
+            self._conn.close()
+
+    def __enter__(self) -> "PostgresStateStore":
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        """Context manager exit."""
+        self.close()
+
+    # KeyMoment operations (implemented)
+
+    def store_key_moments(self, session_id: UUID, moments: list[KeyMoment]) -> None:
+        """
+        Store key moments for a session.
+
+        Args:
+            session_id: UUID of the session
+            moments: List of key moments to store
+        """
+        if not moments:
+            return
+
+        conn = self._get_conn()
+        with conn.cursor() as cur:
+            for moment in moments:
+                # Serialize the KeyMoment to JSON
+                data = json.dumps(moment.model_dump(mode="json"))
+
+                cur.execute(
+                    """
+                    INSERT INTO public.key_moments (id, session_id, data, created_at)
+                    VALUES (%(id)s, %(session_id)s, %(data)s, %(created_at)s)
+                    ON CONFLICT (id) DO NOTHING
+                    """,
+                    {
+                        "id": moment.id,
+                        "session_id": session_id,
+                        "data": data,
+                        "created_at": moment.when,
+                    },
+                )
+            conn.commit()
+
+    def get_key_moment(self, moment_id: UUID) -> KeyMoment | None:
+        """
+        Retrieve a key moment by its ID.
+
+        Args:
+            moment_id: UUID of the key moment
+
+        Returns:
+            KeyMoment | None: The key moment if found, None otherwise
+        """
+        conn = self._get_conn()
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, session_id, data, created_at
+                FROM public.key_moments
+                WHERE id = %(moment_id)s
+                """,
+                {"moment_id": moment_id},
+            )
+            row = cur.fetchone()
+            if row is None:
+                return None
+            return _parse_key_moment(row)
+
+    def get_key_moments_for_session(self, session_id: UUID) -> list[KeyMoment]:
+        """
+        Retrieve all key moments for a session.
+
+        Args:
+            session_id: UUID of the session
+
+        Returns:
+            list[KeyMoment]: List of key moments for the session
+        """
+        conn = self._get_conn()
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, session_id, data, created_at
+                FROM public.key_moments
+                WHERE session_id = %(session_id)s
+                ORDER BY created_at ASC
+                """,
+                {"session_id": session_id},
+            )
+            rows = cur.fetchall()
+            return [_parse_key_moment(row) for row in rows]
+
+    # Experience operations (not implemented)
+
+    def create_experience(self, record: ExperienceRecord) -> ExperienceRecord:
+        """Not implemented in this adapter."""
+        raise NotImplementedError("Experience operations not implemented in PostgresStateStore")
+
+    def get_experience(self, experience_id: UUID) -> ExperienceRecord | None:
+        """Not implemented in this adapter."""
+        raise NotImplementedError("Experience operations not implemented in PostgresStateStore")
+
+    def add_reframing_note(
+        self, experience_id: UUID, note: ReframingNote
+    ) -> ExperienceRecord | None:
+        """Not implemented in this adapter."""
+        raise NotImplementedError("Experience operations not implemented in PostgresStateStore")
+
+    def mark_accessed(self, experience_id: UUID) -> ExperienceRecord | None:
+        """Not implemented in this adapter."""
+        raise NotImplementedError("Experience operations not implemented in PostgresStateStore")
+
+    def search_experiences(
+        self, query: ExperienceQuery | None = None, limit: int = 10
+    ) -> list[ExperienceRecord]:
+        """Not implemented in this adapter."""
+        raise NotImplementedError("Experience operations not implemented in PostgresStateStore")
+
+    def list_recent_experiences(self, limit: int = 10) -> list[ExperienceRecord]:
+        """Not implemented in this adapter."""
+        raise NotImplementedError("Experience operations not implemented in PostgresStateStore")
+
+    # Identity operations (not implemented)
+
+    def load_identity(self, agent_id: UUID) -> Identity | None:
+        """Not implemented in this adapter."""
+        raise NotImplementedError("Identity operations not implemented in PostgresStateStore")
+
+    def save_identity(self, identity: Identity, expected_version: str | None = None) -> Identity:
+        """Not implemented in this adapter."""
+        raise NotImplementedError("Identity operations not implemented in PostgresStateStore")
+
+    def create_identity_snapshot(self, snapshot: IdentitySnapshot) -> IdentitySnapshot:
+        """Not implemented in this adapter."""
+        raise NotImplementedError("Identity operations not implemented in PostgresStateStore")
+
+    def list_identity_snapshots(self, identity_id: UUID, limit: int = 10) -> list[IdentitySnapshot]:
+        """Not implemented in this adapter."""
+        raise NotImplementedError("Identity operations not implemented in PostgresStateStore")
+
+    # Narrative operations (not implemented)
+
+    def load_narrative(self, identity_id: UUID) -> NarrativeDocument | None:
+        """Not implemented in this adapter."""
+        raise NotImplementedError("Narrative operations not implemented in PostgresStateStore")
+
+    def save_narrative(
+        self,
+        narrative: NarrativeDocument,
+        expected_version: str | None = None,
+        expected_updated_at: datetime | None = None,
+    ) -> NarrativeDocument:
+        """Not implemented in this adapter."""
+        raise NotImplementedError("Narrative operations not implemented in PostgresStateStore")
+
+    def archive_narrative(self, narrative_id: UUID, reason: str) -> None:
+        """Not implemented in this adapter."""
+        raise NotImplementedError("Narrative operations not implemented in PostgresStateStore")
+
+    def list_archived_narratives(
+        self, identity_id: UUID, limit: int = 10
+    ) -> list[tuple[NarrativeDocument, str, datetime]]:
+        """Not implemented in this adapter."""
+        raise NotImplementedError("Narrative operations not implemented in PostgresStateStore")
+
+    # Eigenstate operations (not implemented)
+
+    def save_eigenstate(self, eigenstate: Eigenstate) -> Eigenstate:
+        """Not implemented in this adapter."""
+        raise NotImplementedError("Eigenstate operations not implemented in PostgresStateStore")
+
+    def load_latest_eigenstate(
+        self,
+        session_id: UUID | None = None,
+        identity_id: UUID | None = None,
+    ) -> Eigenstate | None:
+        """Not implemented in this adapter."""
+        raise NotImplementedError("Eigenstate operations not implemented in PostgresStateStore")
+
+    # KeyMoment operations (duplicate methods in port - using same implementations)
+
+    def create_key_moment(self, key_moment: KeyMoment) -> KeyMoment:
+        """
+        Create a new key moment in storage.
+
+        Args:
+            key_moment: KeyMoment to store
+
+        Returns:
+            KeyMoment: The stored key moment
+
+        Raises:
+            ValueError: If the key moment already exists
+        """
+        conn = self._get_conn()
+        with conn.cursor() as cur:
+            # Check if moment already exists
+            cur.execute(
+                "SELECT id FROM public.key_moments WHERE id = %(id)s",
+                {"id": key_moment.id},
+            )
+            if cur.fetchone() is not None:
+                raise ValueError(f"KeyMoment {key_moment.id} already exists")
+
+            # Note: We don't have session_id in KeyMoment model, so we use a placeholder
+            # This method may need review when session_id is added to KeyMoment
+            data = json.dumps(key_moment.model_dump(mode="json"))
+
+            cur.execute(
+                """
+                INSERT INTO public.key_moments (id, session_id, data, created_at)
+                VALUES (%(id)s, %(session_id)s, %(data)s, %(created_at)s)
+                """,
+                {
+                    "id": key_moment.id,
+                    "session_id": "00000000-0000-0000-0000-000000000000",  # Placeholder
+                    "data": data,
+                    "created_at": key_moment.when,
+                },
+            )
+            conn.commit()
+
+        return key_moment
+
+    def list_key_moments(self, session_id: UUID | None = None) -> list[KeyMoment]:
+        """
+        List key moments, optionally filtered by session_id.
+
+        Args:
+            session_id: If provided, return only key moments from this session
+
+        Returns:
+            list[KeyMoment]: List of key moments
+        """
+        if session_id is not None:
+            return self.get_key_moments_for_session(session_id)
+
+        conn = self._get_conn()
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, session_id, data, created_at
+                FROM public.key_moments
+                ORDER BY created_at ASC
+                """
+            )
+            rows = cur.fetchall()
+            return [_parse_key_moment(row) for row in rows]

--- a/src/atman/adapters/state/postgres_state_store.py
+++ b/src/atman/adapters/state/postgres_state_store.py
@@ -152,7 +152,7 @@ class PostgresStateStore(StateStore):
             KeyMoment | None: The key moment if found, None otherwise
         """
         conn = self._get_conn()
-        with conn.cursor() as cur:
+        with conn.transaction(), conn.cursor() as cur:
             cur.execute(
                 """
                 SELECT id, session_id, data, created_at
@@ -177,7 +177,7 @@ class PostgresStateStore(StateStore):
             list[KeyMoment]: List of key moments for the session
         """
         conn = self._get_conn()
-        with conn.cursor() as cur:
+        with conn.transaction(), conn.cursor() as cur:
             cur.execute(
                 """
                 SELECT id, session_id, data, created_at
@@ -306,7 +306,7 @@ class PostgresStateStore(StateStore):
                 """,
                 {
                     "id": key_moment.id,
-                    "session_id": "00000000-0000-0000-0000-000000000000",  # Placeholder
+                    "session_id": UUID("00000000-0000-0000-0000-000000000000"),  # Placeholder
                     "data": data,
                     "created_at": key_moment.when,
                 },
@@ -332,7 +332,7 @@ class PostgresStateStore(StateStore):
             return self.get_key_moments_for_session(session_id)
 
         conn = self._get_conn()
-        with conn.cursor() as cur:
+        with conn.transaction(), conn.cursor() as cur:
             cur.execute(
                 """
                 SELECT id, session_id, data, created_at

--- a/src/atman/adapters/state/postgres_state_store.py
+++ b/src/atman/adapters/state/postgres_state_store.py
@@ -124,15 +124,15 @@ class PostgresStateStore(StateStore):
         conn = self._get_conn()
         with conn.transaction(), conn.cursor() as cur:
             for moment in moments:
-                # Serialize the KeyMoment to JSON
-                data = json.dumps(moment.model_dump(mode="json"))
+                # Serialize the KeyMoment to JSONB
+                data = Jsonb(moment.model_dump(mode="json"))
 
                 cur.execute(
                     """
-                        INSERT INTO public.key_moments (id, session_id, data, created_at)
-                        VALUES (%(id)s, %(session_id)s, %(data)s, %(created_at)s)
-                        ON CONFLICT (id) DO NOTHING
-                        """,
+                    INSERT INTO public.key_moments (id, session_id, data, created_at)
+                    VALUES (%(id)s, %(session_id)s, %(data)s, %(created_at)s)
+                    ON CONFLICT (id) DO NOTHING
+                    """,
                     {
                         "id": moment.id,
                         "session_id": session_id,
@@ -296,14 +296,14 @@ class PostgresStateStore(StateStore):
         with conn.transaction(), conn.cursor() as cur:
             # Note: We don't have session_id in KeyMoment model, so we use a placeholder
             # This method may need review when session_id is added to KeyMoment
-            data = json.dumps(key_moment.model_dump(mode="json"))
+            data = Jsonb(key_moment.model_dump(mode="json"))
 
             cur.execute(
                 """
-                    INSERT INTO public.key_moments (id, session_id, data, created_at)
-                    VALUES (%(id)s, %(session_id)s, %(data)s, %(created_at)s)
-                    ON CONFLICT (id) DO NOTHING
-                    """,
+                INSERT INTO public.key_moments (id, session_id, data, created_at)
+                VALUES (%(id)s, %(session_id)s, %(data)s, %(created_at)s)
+                ON CONFLICT (id) DO NOTHING
+                """,
                 {
                     "id": key_moment.id,
                     "session_id": "00000000-0000-0000-0000-000000000000",  # Placeholder

--- a/tests/test_postgres_state_store.py
+++ b/tests/test_postgres_state_store.py
@@ -41,7 +41,13 @@ def store(db_url: str) -> Any:
     """Create a PostgresStateStore instance for testing."""
     from atman.adapters.state import PostgresStateStore
 
-    return PostgresStateStore(db_url=db_url)
+    s = PostgresStateStore(db_url=db_url)
+    # Clean up before test
+    conn = s._get_conn()
+    with conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE public.key_moments")
+    conn.commit()
+    return s
 
 
 @pytest.fixture

--- a/tests/test_postgres_state_store.py
+++ b/tests/test_postgres_state_store.py
@@ -1,0 +1,348 @@
+"""Tests for PostgresStateStore KeyMoment operations."""
+
+import os
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from atman.core.models import EmotionalDepth, FeltSense, KeyMoment
+
+# Skip all tests if psycopg is not installed
+try:
+    import psycopg  # noqa: F401
+
+    from atman.adapters.state import PostgresStateStore
+
+    PSYCOPG_AVAILABLE = True
+except ImportError:
+    PSYCOPG_AVAILABLE = False
+    PostgresStateStore = Any  # type: ignore[misc]
+
+# Skip all tests in this module if psycopg is not available or if no test database
+pytestmark = [
+    pytest.mark.skipif(not PSYCOPG_AVAILABLE, reason="psycopg not installed"),
+    pytest.mark.skipif(
+        not os.environ.get("TEST_DB_URL"),
+        reason="TEST_DB_URL not set - skipping PostgresStateStore tests",
+    ),
+]
+
+
+@pytest.fixture
+def db_url() -> str:
+    """Return test database URL from environment."""
+    return os.environ.get("TEST_DB_URL", "postgresql://atman@localhost:5432/atman_test")
+
+
+@pytest.fixture
+def store(db_url: str) -> Any:
+    """Create a PostgresStateStore instance for testing."""
+    from atman.adapters.state import PostgresStateStore
+
+    return PostgresStateStore(db_url=db_url)
+
+
+@pytest.fixture
+def sample_key_moment() -> KeyMoment:
+    """Create a sample KeyMoment for testing."""
+    return KeyMoment(
+        id=uuid4(),
+        what_happened="User asked me to implement a complex feature",
+        when=datetime(2026, 5, 12, 10, 30, 0, tzinfo=UTC),
+        how_i_felt=FeltSense(
+            emotional_valence=-0.2,
+            emotional_intensity=0.6,
+            depth=EmotionalDepth.MEANINGFUL,
+        ),
+        why_it_matters="This challenged my confidence in my capabilities",
+        values_touched=["competence", "honesty"],
+        principles_confirmed=["admit_when_uncertain"],
+        principles_questioned=[],
+        what_changed="Realized I need to be more upfront about my limitations",
+    )
+
+
+def test_store_key_moments_single(store: Any, sample_key_moment: KeyMoment) -> None:
+    """Test storing a single key moment."""
+    session_id = uuid4()
+
+    # Store the moment
+    store.store_key_moments(session_id, [sample_key_moment])
+
+    # Retrieve it back
+    moments = store.get_key_moments_for_session(session_id)
+
+    assert len(moments) == 1
+    assert moments[0].id == sample_key_moment.id
+    assert moments[0].what_happened == sample_key_moment.what_happened
+    assert moments[0].why_it_matters == sample_key_moment.why_it_matters
+
+
+def test_store_key_moments_multiple(store: Any) -> None:
+    """Test storing multiple key moments for a session."""
+    session_id = uuid4()
+
+    moments = [
+        KeyMoment(
+            id=uuid4(),
+            what_happened=f"Event {i}",
+            how_i_felt=FeltSense(
+                emotional_valence=0.5,
+                emotional_intensity=0.7,
+                depth=EmotionalDepth.SURFACE,
+            ),
+            why_it_matters=f"Reason {i}",
+        )
+        for i in range(3)
+    ]
+
+    # Store all moments
+    store.store_key_moments(session_id, moments)
+
+    # Retrieve them back
+    retrieved = store.get_key_moments_for_session(session_id)
+
+    assert len(retrieved) == 3
+    assert {m.id for m in retrieved} == {m.id for m in moments}
+
+
+def test_get_key_moment_by_id(store: Any, sample_key_moment: KeyMoment) -> None:
+    """Test retrieving a key moment by its ID."""
+    session_id = uuid4()
+
+    # Store the moment
+    store.store_key_moments(session_id, [sample_key_moment])
+
+    # Retrieve by ID
+    moment = store.get_key_moment(sample_key_moment.id)
+
+    assert moment is not None
+    assert moment.id == sample_key_moment.id
+    assert moment.what_happened == sample_key_moment.what_happened
+
+
+def test_get_key_moment_not_found(store: Any) -> None:
+    """Test retrieving a non-existent key moment returns None."""
+    random_id = uuid4()
+    moment = store.get_key_moment(random_id)
+    assert moment is None
+
+
+def test_get_key_moments_for_session_empty(store: Any) -> None:
+    """Test retrieving moments for a session with no moments."""
+    session_id = uuid4()
+    moments = store.get_key_moments_for_session(session_id)
+    assert moments == []
+
+
+def test_store_key_moments_idempotent(store: Any, sample_key_moment: KeyMoment) -> None:
+    """Test that storing the same moment twice is idempotent."""
+    session_id = uuid4()
+
+    # Store twice
+    store.store_key_moments(session_id, [sample_key_moment])
+    store.store_key_moments(session_id, [sample_key_moment])
+
+    # Should still have only one moment
+    moments = store.get_key_moments_for_session(session_id)
+    assert len(moments) == 1
+
+
+def test_create_key_moment_raises_on_duplicate(store: Any, sample_key_moment: KeyMoment) -> None:
+    """Test that create_key_moment raises ValueError for duplicate IDs."""
+    # Store first time using store_key_moments
+    session_id = uuid4()
+    store.store_key_moments(session_id, [sample_key_moment])
+
+    # Try to create again using create_key_moment
+    with pytest.raises(ValueError, match="already exists"):
+        store.create_key_moment(sample_key_moment)
+
+
+def test_list_key_moments_all(store: Any) -> None:
+    """Test listing all key moments across sessions."""
+    session1 = uuid4()
+    session2 = uuid4()
+
+    moment1 = KeyMoment(
+        id=uuid4(),
+        what_happened="Event 1",
+        how_i_felt=FeltSense(
+            emotional_valence=0.5,
+            emotional_intensity=0.7,
+            depth=EmotionalDepth.SURFACE,
+        ),
+        why_it_matters="Reason 1",
+    )
+    moment2 = KeyMoment(
+        id=uuid4(),
+        what_happened="Event 2",
+        how_i_felt=FeltSense(
+            emotional_valence=0.3,
+            emotional_intensity=0.5,
+            depth=EmotionalDepth.MEANINGFUL,
+        ),
+        why_it_matters="Reason 2",
+    )
+
+    store.store_key_moments(session1, [moment1])
+    store.store_key_moments(session2, [moment2])
+
+    # List all moments
+    all_moments = store.list_key_moments()
+
+    assert len(all_moments) >= 2
+    moment_ids = {m.id for m in all_moments}
+    assert moment1.id in moment_ids
+    assert moment2.id in moment_ids
+
+
+def test_list_key_moments_filtered_by_session(store: Any) -> None:
+    """Test listing key moments filtered by session."""
+    session1 = uuid4()
+    session2 = uuid4()
+
+    moment1 = KeyMoment(
+        id=uuid4(),
+        what_happened="Event 1",
+        how_i_felt=FeltSense(
+            emotional_valence=0.5,
+            emotional_intensity=0.7,
+            depth=EmotionalDepth.SURFACE,
+        ),
+        why_it_matters="Reason 1",
+    )
+    moment2 = KeyMoment(
+        id=uuid4(),
+        what_happened="Event 2",
+        how_i_felt=FeltSense(
+            emotional_valence=0.3,
+            emotional_intensity=0.5,
+            depth=EmotionalDepth.MEANINGFUL,
+        ),
+        why_it_matters="Reason 2",
+    )
+
+    store.store_key_moments(session1, [moment1])
+    store.store_key_moments(session2, [moment2])
+
+    # List moments for session1 only
+    session1_moments = store.list_key_moments(session_id=session1)
+
+    assert len(session1_moments) == 1
+    assert session1_moments[0].id == moment1.id
+
+
+def test_unimplemented_experience_operations(store: Any) -> None:
+    """Test that experience operations raise NotImplementedError."""
+    from atman.core.models import ExperienceRecord, ReframingNote, SessionExperience
+
+    with pytest.raises(NotImplementedError):
+        store.create_experience(
+            ExperienceRecord(
+                experience=SessionExperience(
+                    session_id=uuid4(),
+                    key_moment_ids=[uuid4()],
+                )
+            )
+        )
+
+    with pytest.raises(NotImplementedError):
+        store.get_experience(uuid4())
+
+    with pytest.raises(NotImplementedError):
+        store.add_reframing_note(
+            uuid4(), ReframingNote(reflection="test", reflection_type="general")
+        )
+
+    with pytest.raises(NotImplementedError):
+        store.mark_accessed(uuid4())
+
+    with pytest.raises(NotImplementedError):
+        store.search_experiences()
+
+    with pytest.raises(NotImplementedError):
+        store.list_recent_experiences()
+
+
+def test_unimplemented_identity_operations(store: Any) -> None:
+    """Test that identity operations raise NotImplementedError."""
+    from atman.core.models import Identity, IdentitySnapshot
+
+    with pytest.raises(NotImplementedError):
+        store.load_identity(uuid4())
+
+    with pytest.raises(NotImplementedError):
+        store.save_identity(Identity(id=uuid4()))
+
+    with pytest.raises(NotImplementedError):
+        store.create_identity_snapshot(
+            IdentitySnapshot(
+                id=uuid4(),
+                identity_id=uuid4(),
+                timestamp=datetime.now(UTC),
+                identity_snapshot=Identity(id=uuid4()),
+            )
+        )
+
+    with pytest.raises(NotImplementedError):
+        store.list_identity_snapshots(uuid4())
+
+
+def test_unimplemented_narrative_operations(store: Any) -> None:
+    """Test that narrative operations raise NotImplementedError."""
+    from atman.core.models import LayerType, NarrativeDocument, NarrativeLayer
+
+    with pytest.raises(NotImplementedError):
+        store.load_narrative(uuid4())
+
+    with pytest.raises(NotImplementedError):
+        store.save_narrative(
+            NarrativeDocument(
+                id=uuid4(),
+                identity_id=uuid4(),
+                core_layer=NarrativeLayer(content="", layer_type=LayerType.CORE),
+                recent_layer=NarrativeLayer(content="", layer_type=LayerType.RECENT),
+            )
+        )
+
+    with pytest.raises(NotImplementedError):
+        store.archive_narrative(uuid4(), "test")
+
+    with pytest.raises(NotImplementedError):
+        store.list_archived_narratives(uuid4())
+
+
+def test_unimplemented_eigenstate_operations(store: Any) -> None:
+    """Test that eigenstate operations raise NotImplementedError."""
+    from atman.core.models import Eigenstate
+
+    with pytest.raises(NotImplementedError):
+        store.save_eigenstate(
+            Eigenstate(
+                id=uuid4(),
+                session_id=uuid4(),
+                identity_id=uuid4(),
+                timestamp=datetime.now(UTC),
+            )
+        )
+
+    with pytest.raises(NotImplementedError):
+        store.load_latest_eigenstate()
+
+
+def test_context_manager(db_url: str, sample_key_moment: KeyMoment) -> None:
+    """Test that PostgresStateStore works as a context manager."""
+    from atman.adapters.state import PostgresStateStore
+
+    session_id = uuid4()
+
+    with PostgresStateStore(db_url=db_url) as store:
+        store.store_key_moments(session_id, [sample_key_moment])
+        moments = store.get_key_moments_for_session(session_id)
+        assert len(moments) == 1
+
+    # Connection should be closed after exiting context
+    # (We can't easily test this without accessing private state)

--- a/tests/test_state_store_contract.py
+++ b/tests/test_state_store_contract.py
@@ -10,6 +10,7 @@ SYSTEM_MAP §2.1 / §5.3 regression freeze.
 
 from __future__ import annotations
 
+import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -46,17 +47,34 @@ from atman.core.ports.state_store import (
     ValuesTouchedQuery,
 )
 
+try:
+    import psycopg  # noqa: F401
+
+    from atman.adapters.state import PostgresStateStore
+
+    POSTGRES_AVAILABLE = True
+except ImportError:
+    POSTGRES_AVAILABLE = False
+    PostgresStateStore = None  # type: ignore
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(params=["file", "in_memory"])
+@pytest.fixture(params=["file", "in_memory", "postgres"])
 def store(request, tmp_path: Path) -> StateStore:
     if request.param == "file":
         return FileStateStore(tmp_path)
     if request.param == "in_memory":
         return InMemoryStateStore()
+    if request.param == "postgres":
+        if not POSTGRES_AVAILABLE or PostgresStateStore is None:
+            pytest.skip("psycopg not installed")
+        db_url = os.environ.get("TEST_DB_URL")
+        if not db_url:
+            pytest.skip("TEST_DB_URL not set")
+        return PostgresStateStore(db_url=db_url)
     raise NotImplementedError(request.param)
 
 
@@ -586,10 +604,18 @@ def test_list_key_moments_returns_all(store: StateStore) -> None:
 
 
 def test_list_key_moments_with_session_id_raises_not_implemented(store: StateStore) -> None:
-    """Test that filtering by session_id raises NotImplementedError."""
+    """Test that filtering by session_id raises NotImplementedError.
+
+    Note: PostgresStateStore actually implements this feature, so it's
+    excluded from this test.
+    """
     # Skip for stores that don't support KeyMoment operations
     if isinstance(store, InMemoryExperienceStore | JsonlExperienceStore):
         pytest.skip("Store doesn't support KeyMoment operations")
+
+    # PostgresStateStore actually supports session_id filtering
+    if POSTGRES_AVAILABLE and PostgresStateStore is not None and isinstance(store, PostgresStateStore):
+        pytest.skip("PostgresStateStore supports session_id filtering")
 
     with pytest.raises(NotImplementedError, match="session_id"):
         store.list_key_moments(session_id=uuid4())

--- a/tests/test_state_store_contract.py
+++ b/tests/test_state_store_contract.py
@@ -614,7 +614,11 @@ def test_list_key_moments_with_session_id_raises_not_implemented(store: StateSto
         pytest.skip("Store doesn't support KeyMoment operations")
 
     # PostgresStateStore actually supports session_id filtering
-    if POSTGRES_AVAILABLE and PostgresStateStore is not None and isinstance(store, PostgresStateStore):
+    if (
+        POSTGRES_AVAILABLE
+        and PostgresStateStore is not None
+        and isinstance(store, PostgresStateStore)
+    ):
         pytest.skip("PostgresStateStore supports session_id filtering")
 
     with pytest.raises(NotImplementedError, match="session_id"):

--- a/tests/test_state_store_contract.py
+++ b/tests/test_state_store_contract.py
@@ -74,8 +74,24 @@ def store(request, tmp_path: Path) -> StateStore:
         db_url = os.environ.get("TEST_DB_URL")
         if not db_url:
             pytest.skip("TEST_DB_URL not set")
-        return PostgresStateStore(db_url=db_url)
+        s = PostgresStateStore(db_url=db_url)
+        # Clean up before test
+        conn = s._get_conn()
+        with conn.cursor() as cur:
+            cur.execute("TRUNCATE TABLE public.key_moments")
+        conn.commit()
+        return s
     raise NotImplementedError(request.param)
+
+
+def _skip_if_postgres_partial(store: StateStore) -> None:
+    """Skip test if store is PostgresStateStore (only implements KeyMoment ops)."""
+    if (
+        POSTGRES_AVAILABLE
+        and PostgresStateStore is not None
+        and isinstance(store, PostgresStateStore)
+    ):
+        pytest.skip("PostgresStateStore only implements KeyMoment operations")
 
 
 def _make_record(
@@ -135,6 +151,7 @@ def _make_narrative(identity_id) -> NarrativeDocument:
 
 
 def test_create_and_get_experience(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     record, moment = _make_record()
     stored = _persist(store, record, moment)
     assert stored.experience.id == record.experience.id
@@ -145,10 +162,12 @@ def test_create_and_get_experience(store: StateStore) -> None:
 
 
 def test_get_experience_unknown_returns_none(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     assert store.get_experience(uuid4()) is None
 
 
 def test_create_experience_duplicate_raises(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     record, moment = _make_record()
     _persist(store, record, moment)
     with pytest.raises(Exception):
@@ -156,6 +175,7 @@ def test_create_experience_duplicate_raises(store: StateStore) -> None:
 
 
 def test_add_reframing_note(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     record, moment = _make_record()
     _persist(store, record, moment)
 
@@ -166,11 +186,13 @@ def test_add_reframing_note(store: StateStore) -> None:
 
 
 def test_add_reframing_note_unknown_returns_none(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     note = ReframingNote(reflection="x", reflection_type="growth")
     assert store.add_reframing_note(uuid4(), note) is None
 
 
 def test_add_reframing_note_preserves_key_moments(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     record, moment = _make_record()
     original_moment = moment.what_happened
     _persist(store, record, moment)
@@ -185,6 +207,7 @@ def test_add_reframing_note_preserves_key_moments(store: StateStore) -> None:
 
 
 def test_mark_accessed(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     record, moment = _make_record()
     _persist(store, record, moment)
     updated = store.mark_accessed(record.experience.id)
@@ -193,10 +216,12 @@ def test_mark_accessed(store: StateStore) -> None:
 
 
 def test_mark_accessed_unknown_returns_none(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     assert store.mark_accessed(uuid4()) is None
 
 
 def test_list_recent_experiences_newest_first(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     base = datetime.now(UTC)
     for i in range(3):
         rec, m = _make_record(timestamp=base + timedelta(minutes=i))
@@ -209,6 +234,7 @@ def test_list_recent_experiences_newest_first(store: StateStore) -> None:
 
 
 def test_search_by_session(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     sid = uuid4()
     r1, m1 = _make_record(session_id=sid)
     _persist(store, r1, m1)
@@ -221,6 +247,7 @@ def test_search_by_session(store: StateStore) -> None:
 
 
 def test_search_by_values(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     r1, m1 = _make_record(values=["courage", "honesty"])
     _persist(store, r1, m1)
     r2, m2 = _make_record(values=["patience"])
@@ -231,6 +258,7 @@ def test_search_by_values(store: StateStore) -> None:
 
 
 def test_search_by_depth(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     r1, m1 = _make_record(depth=EmotionalDepth.PROFOUND)
     _persist(store, r1, m1)
     r2, m2 = _make_record(depth=EmotionalDepth.SURFACE)
@@ -245,6 +273,7 @@ def test_search_by_depth(store: StateStore) -> None:
 
 
 def test_search_by_date_range_excludes_outside(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     now = datetime.now(UTC)
     inside, mi = _make_record(timestamp=now)
     outside, mo = _make_record(timestamp=now - timedelta(days=10))
@@ -258,6 +287,7 @@ def test_search_by_date_range_excludes_outside(store: StateStore) -> None:
 
 
 def test_search_by_fact_refs(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     """Contract test: FactRefsContainsQuery filters by fact_refs in key moments."""
     fact_id = uuid4()
     other_fact_id = uuid4()
@@ -334,6 +364,7 @@ def test_search_by_fact_refs(store: StateStore) -> None:
 
 
 def test_save_and_load_identity(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     identity = _make_identity()
     store.save_identity(identity)
 
@@ -343,10 +374,12 @@ def test_save_and_load_identity(store: StateStore) -> None:
 
 
 def test_load_identity_unknown_returns_none(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     assert store.load_identity(uuid4()) is None
 
 
 def test_create_and_list_identity_snapshots(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     identity = _make_identity()
     store.save_identity(identity)
 
@@ -364,6 +397,7 @@ def test_create_and_list_identity_snapshots(store: StateStore) -> None:
 
 
 def test_list_identity_snapshots_filters_by_identity(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     id1 = _make_identity()
     id2 = _make_identity()
     store.save_identity(id1)
@@ -387,6 +421,7 @@ def test_list_identity_snapshots_filters_by_identity(store: StateStore) -> None:
 
 
 def test_save_and_load_narrative(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     identity = _make_identity()
     store.save_identity(identity)
     narrative = _make_narrative(identity.id)
@@ -398,6 +433,7 @@ def test_save_and_load_narrative(store: StateStore) -> None:
 
 
 def test_load_narrative_unknown_identity_returns_none(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     assert store.load_narrative(uuid4()) is None
 
 
@@ -407,6 +443,7 @@ def test_load_narrative_unknown_identity_returns_none(store: StateStore) -> None
 
 
 def test_save_and_load_eigenstate(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     eigenstate = Eigenstate(
         session_id=uuid4(),
         emotional_tone=0.3,
@@ -426,10 +463,12 @@ def test_save_and_load_eigenstate(store: StateStore) -> None:
 
 
 def test_load_latest_eigenstate_no_data_returns_none(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     assert store.load_latest_eigenstate() is None
 
 
 def test_load_latest_eigenstate_filters_by_session(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     sid = uuid4()
     e = Eigenstate(
         session_id=sid,
@@ -449,6 +488,7 @@ def test_load_latest_eigenstate_filters_by_session(store: StateStore) -> None:
 
 
 def test_load_latest_eigenstate_filters_by_identity(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     sid = uuid4()
     iid = uuid4()
     e = Eigenstate(
@@ -470,6 +510,7 @@ def test_load_latest_eigenstate_filters_by_identity(store: StateStore) -> None:
 
 
 def test_save_identity_expected_version_mismatch_raises(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     ident = _make_identity()
     store.save_identity(ident)
     stale = ident.model_copy(update={"self_description": "changed"})
@@ -478,6 +519,7 @@ def test_save_identity_expected_version_mismatch_raises(store: StateStore) -> No
 
 
 def test_save_narrative_optimistic_lock_mismatch_raises(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     ident = _make_identity()
     narrative = _make_narrative(ident.id)
     store.save_narrative(narrative)
@@ -508,6 +550,7 @@ def test_save_narrative_optimistic_lock_mismatch_raises(store: StateStore) -> No
 
 
 def test_archive_narrative_and_list(store: StateStore) -> None:
+    _skip_if_postgres_partial(store)
     ident = _make_identity()
     narrative = _make_narrative(ident.id)
     store.save_narrative(narrative)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This pull request contains changes generated by a Cursor Cloud Agent
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf4c0bb0-dafc-45f5-b253-243ac253b372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf4c0bb0-dafc-45f5-b253-243ac253b372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hleserg/atman/pull/520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->