### PR TITLE
feat(agent-cli): providers & RAG config fields

### DIFF
--- a/atman_agent_cli/src/atman/agent_cli/config.py
+++ b/atman_agent_cli/src/atman/agent_cli/config.py
@@ -3,11 +3,12 @@ atman/agent_cli/config.py
 Configuration for the Atman agent CLI.
 Not included in production release — optional dependency [agent].
 """
+
 from __future__ import annotations
 
 import os
-from pathlib import Path
 from dataclasses import dataclass, field
+from pathlib import Path
 
 
 @dataclass
@@ -20,24 +21,18 @@ class AgentConfig:
     llm_url: str = field(
         default_factory=lambda: os.getenv("ATMAN_LLM_URL", "http://localhost:8080")
     )
-    llm_model: str = field(
-        default_factory=lambda: os.getenv("ATMAN_LLM_MODEL", "gemma4")
-    )
-    llm_temperature: float = 0.2   # низкая для кода
+    llm_model: str = field(default_factory=lambda: os.getenv("ATMAN_LLM_MODEL", "gemma4"))
+    llm_temperature: float = 0.2  # низкая для кода
     llm_max_tokens: int = 4096
     llm_timeout: int = 120
 
     # ── Planner: Cohere ───────────────────────────────────────────────
-    cohere_api_key: str = field(
-        default_factory=lambda: os.getenv("COHERE_API_KEY", "")
-    )
+    cohere_api_key: str = field(default_factory=lambda: os.getenv("COHERE_API_KEY", ""))
     cohere_model: str = "command-r-plus"
     cohere_temperature: float = 0.3
 
     # ── GitHub ────────────────────────────────────────────────────────
-    github_token: str = field(
-        default_factory=lambda: os.getenv("GITHUB_TOKEN", "")
-    )
+    github_token: str = field(default_factory=lambda: os.getenv("GITHUB_TOKEN", ""))
     github_repo: str = field(
         default_factory=lambda: os.getenv("ATMAN_GITHUB_REPO", "hleserg/atman")
     )
@@ -46,19 +41,15 @@ class AgentConfig:
     # ── RAG ───────────────────────────────────────────────────────────
     embed_model: str = "BAAI/bge-m3"
     reranker_model: str = "BAAI/bge-reranker-v2-m3"
-    rag_top_k: int = 50        # BGE-M3 candidates
-    rag_top_n: int = 5         # after reranker
-    index_path: Path = field(
-        default_factory=lambda: Path.home() / ".atman" / "agent_index"
-    )
+    rag_top_k: int = 50  # BGE-M3 candidates
+    rag_top_n: int = 5  # after reranker
+    index_path: Path = field(default_factory=lambda: Path.home() / ".atman" / "agent_index")
 
     # ── Memory (Atman) ────────────────────────────────────────────────
-    memory_path: Path = field(
-        default_factory=lambda: Path.home() / ".atman" / "agent_memory"
-    )
+    memory_path: Path = field(default_factory=lambda: Path.home() / ".atman" / "agent_memory")
 
     # ── Babysit ───────────────────────────────────────────────────────
-    babysit_poll_interval: int = 30    # seconds
+    babysit_poll_interval: int = 30  # seconds
     babysit_max_fix_attempts: int = 5
     babysit_require_approval: bool = True  # if False → merge as soon as CI green
 
@@ -70,9 +61,7 @@ class AgentConfig:
     context_critical_ratio: float = 0.90
 
     # ── UI ────────────────────────────────────────────────────────────
-    history_file: Path = field(
-        default_factory=lambda: Path.home() / ".atman" / "agent_history"
-    )
+    history_file: Path = field(default_factory=lambda: Path.home() / ".atman" / "agent_history")
 
     def __post_init__(self) -> None:
         self.repo_path = Path(self.repo_path)
@@ -88,6 +77,7 @@ class AgentConfig:
             return
         try:
             import json
+
             data = json.loads(self._settings_file.read_text())
             for key, val in data.items():
                 if hasattr(self, key):
@@ -98,12 +88,25 @@ class AgentConfig:
     def save_settings(self) -> None:
         """Persist mutable settings to disk."""
         import json
+
         PERSIST_KEYS = [
-            "main_branch", "llm_url", "llm_model", "llm_temperature",
-            "llm_max_tokens", "llm_timeout", "cohere_model", "cohere_temperature",
-            "github_repo", "rag_top_k", "rag_top_n",
-            "babysit_poll_interval", "babysit_max_fix_attempts", "babysit_require_approval",
-            "context_limit", "context_warn_ratio", "context_critical_ratio",
+            "main_branch",
+            "llm_url",
+            "llm_model",
+            "llm_temperature",
+            "llm_max_tokens",
+            "llm_timeout",
+            "cohere_model",
+            "cohere_temperature",
+            "github_repo",
+            "rag_top_k",
+            "rag_top_n",
+            "babysit_poll_interval",
+            "babysit_max_fix_attempts",
+            "babysit_require_approval",
+            "context_limit",
+            "context_warn_ratio",
+            "context_critical_ratio",
         ]
         data = {k: getattr(self, k) for k in PERSIST_KEYS}
         self._settings_file.write_text(json.dumps(data, indent=2))

--- a/atman_agent_cli/src/atman/agent_cli/providers.py
+++ b/atman_agent_cli/src/atman/agent_cli/providers.py
@@ -364,10 +364,16 @@ Give concise, actionable plans. Be specific about files and patterns to use."""
     def _rerank_cohere(self, query: str, passages: list[str], top_n: int) -> list[float]:
         try:
             co = _get_cohere_client(self.secrets.cohere_api_key)
+            model = COHERE_RERANK_MODEL
+            ac = getattr(self, "_agent_cfg", None)
+            if ac is not None:
+                override = getattr(ac, "cohere_rerank_model", None)
+                if isinstance(override, str) and override.strip():
+                    model = override.strip()
             resp = co.rerank(
                 query=query,
                 documents=passages,
-                model=COHERE_RERANK_MODEL,
+                model=model,
                 top_n=top_n,
             )
             scores = [0.0] * len(passages)
@@ -422,6 +428,100 @@ Give concise, actionable plans. Be specific about files and patterns to use."""
             ("embedder", self.cfg.embedder, " | ".join(EMBEDDER_PROVIDERS)),
             ("reranker", self.cfg.reranker, " | ".join(RERANKER_PROVIDERS)),
         ]
+
+    def update_llm_url(self, new_url: str) -> None:
+        """Update llama.cpp server URL without restart."""
+        self.llm_url = new_url
+        ac = getattr(self, "_agent_cfg", None)
+        if ac is not None:
+            ac.llm_url = new_url
+            ac.save_settings()
+
+    def get_sidebar_info(self) -> dict[str, str]:
+        """Compact provider summary for TUI sidebars."""
+        parts = self.llm_url.split("/")
+        host = parts[2] if len(parts) > 2 else self.llm_url
+        return {
+            "coder": f"{self.cfg.coder} @ {host}",
+            "planner": self.cfg.planner,
+            "embedder": self.cfg.embedder,
+            "reranker": self.cfg.reranker,
+        }
+
+    def plan_with_documents(
+        self,
+        user_message: str,
+        rag_chunks: list,
+    ) -> tuple[str, list[dict]]:
+        """
+        Planner with optional RAG chunks as grounded documents (Cohere citations).
+
+        Returns (answer text, citations) where each citation is
+        {"source": "path:line", "text": "..."}.
+        """
+        if self.cfg.planner != "cohere":
+            context = "\n\n".join(
+                f"[{c.path}:{c.start_line}]\n{getattr(c, 'window_content', c.content)}"
+                for c in rag_chunks
+            )
+            full_message = f"{context}\n\n{user_message}"
+            return self._route_planner(full_message), []
+
+        try:
+            co = _get_cohere_client(self.secrets.cohere_api_key)
+
+            def _chunk_metadata(chunk: object) -> dict:
+                md = getattr(chunk, "metadata", None)
+                if isinstance(md, dict):
+                    return md
+                return {}
+
+            response = co.chat(
+                model="command-a-03-2025",
+                message=user_message,
+                documents=[
+                    {
+                        "id": str(i),
+                        "data": {
+                            "text": getattr(c, "window_content", c.content),
+                            "source": f"{c.path}:{c.start_line}",
+                            "type": _chunk_metadata(c).get("type", "code"),
+                        },
+                    }
+                    for i, c in enumerate(rag_chunks)
+                ],
+                preamble=self.SYSTEM_PLANNER,
+            )
+
+            answer = getattr(response, "text", "") or ""
+
+            citations: list[dict[str, str]] = []
+            raw_citations = getattr(response, "citations", None) or []
+            for citation in raw_citations:
+                doc_ids = getattr(citation, "document_ids", None) or []
+                start = getattr(citation, "start", None)
+                end = getattr(citation, "end", None)
+                if start is None or end is None:
+                    continue
+                snippet = answer[start:end]
+                for doc_id in doc_ids:
+                    try:
+                        idx = int(doc_id)
+                        if idx < len(rag_chunks):
+                            chunk = rag_chunks[idx]
+                            citations.append(
+                                {
+                                    "source": f"{chunk.path}:{chunk.start_line}",
+                                    "text": snippet,
+                                }
+                            )
+                    except (ValueError, TypeError):
+                        continue
+
+            return answer, citations
+
+        except Exception as e:
+            return f"[Cohere error: {e}]", []
 
     def _build_messages(self, prompt: str, context: str) -> list[dict]:
         content = f"<context>\n{context}\n</context>\n\n{prompt}" if context else prompt

--- a/atman_agent_cli/src/atman/agent_cli/rag.py
+++ b/atman_agent_cli/src/atman/agent_cli/rag.py
@@ -3,6 +3,7 @@ atman/agent_cli/rag.py
 RAG: BGE-M3 indexing of the Atman repo + bge-reranker-v2-m3 reranking.
 Two-stage retrieval: dense search → reranker → top-N.
 """
+
 from __future__ import annotations
 
 import json
@@ -12,14 +13,23 @@ from pathlib import Path
 from dataclasses import dataclass, asdict
 
 from .config import AgentConfig
+from .providers import ProviderRouter
 
 # File extensions to index
 INDEXABLE_EXTENSIONS = {".py", ".md", ".toml", ".yml", ".yaml", ".txt"}
 SKIP_DIRS = {
-    ".git", "__pycache__", ".venv", "venv", "node_modules",
-    ".mypy_cache", ".ruff_cache", "dist", "build", ".pytest_cache",
+    ".git",
+    "__pycache__",
+    ".venv",
+    "venv",
+    "node_modules",
+    ".mypy_cache",
+    ".ruff_cache",
+    "dist",
+    "build",
+    ".pytest_cache",
 }
-MAX_CHUNK_CHARS = 2000   # chars per chunk
+MAX_CHUNK_CHARS = 2000  # chars per chunk
 CHUNK_OVERLAP = 200
 
 
@@ -47,6 +57,7 @@ class RAGIndex:
 
     def __init__(self, cfg: AgentConfig) -> None:
         self.cfg = cfg
+        self.router: ProviderRouter | None = None
         self.index_path = cfg.index_path
         self._chunks: list[Chunk] = []
         self._embeddings: list[list[float]] = []
@@ -58,6 +69,7 @@ class RAGIndex:
     def _load_models(self) -> None:
         try:
             from FlagEmbedding import BGEM3FlagModel, FlagReranker
+
             self._embedder = BGEM3FlagModel(
                 self.cfg.embed_model,
                 use_fp16=True,
@@ -123,13 +135,15 @@ class RAGIndex:
                 h = self._file_hash(path)
                 rel = str(path.relative_to(repo))
                 for j, (chunk_text, start_line) in enumerate(self._chunk_text(text, rel)):
-                    self._chunks.append(Chunk(
-                        path=rel,
-                        content=chunk_text,
-                        start_line=start_line,
-                        chunk_index=j,
-                        file_hash=h,
-                    ))
+                    self._chunks.append(
+                        Chunk(
+                            path=rel,
+                            content=chunk_text,
+                            start_line=start_line,
+                            chunk_index=j,
+                            file_hash=h,
+                        )
+                    )
                     raw_texts.append(chunk_text)
             except Exception:
                 continue
@@ -167,7 +181,9 @@ class RAGIndex:
             # Remove old chunks for this file
             indices_to_remove = set(existing.get(rel, []))
             self._chunks = [c for i, c in enumerate(self._chunks) if i not in indices_to_remove]
-            self._embeddings = [e for i, e in enumerate(self._embeddings) if i not in indices_to_remove]
+            self._embeddings = [
+                e for i, e in enumerate(self._embeddings) if i not in indices_to_remove
+            ]
 
             # Add new chunks
             try:
@@ -175,10 +191,15 @@ class RAGIndex:
                 new_chunks = []
                 new_texts = []
                 for j, (chunk_text, start_line) in enumerate(self._chunk_text(text, rel)):
-                    new_chunks.append(Chunk(
-                        path=rel, content=chunk_text,
-                        start_line=start_line, chunk_index=j, file_hash=h,
-                    ))
+                    new_chunks.append(
+                        Chunk(
+                            path=rel,
+                            content=chunk_text,
+                            start_line=start_line,
+                            chunk_index=j,
+                            file_hash=h,
+                        )
+                    )
                     new_texts.append(chunk_text)
 
                 if self._embedder and new_texts:
@@ -214,8 +235,9 @@ class RAGIndex:
         if not candidates:
             return []
 
-        # Stage 2: rerank
-        if self._reranker and len(candidates) > n:
+        # Stage 2: rerank (local FlagReranker and/or ProviderRouter Cohere)
+        cohere_rerank = bool(self.router is not None and self.router.cfg.reranker == "cohere")
+        if len(candidates) > n and (self._reranker or cohere_rerank):
             return self._rerank(query, candidates, n)
 
         return candidates[:n]
@@ -225,8 +247,7 @@ class RAGIndex:
             # Fallback: keyword search
             query_lower = query.lower()
             scored = [
-                (sum(w in c.content.lower() for w in query_lower.split()), c)
-                for c in self._chunks
+                (sum(w in c.content.lower() for w in query_lower.split()), c) for c in self._chunks
             ]
             scored.sort(reverse=True)
             return [c for _, c in scored[:top_k] if _ > 0]
@@ -237,6 +258,7 @@ class RAGIndex:
 
         # Cosine similarity
         import numpy as np
+
         embeddings = np.array(self._embeddings)
         q_norm = q_vec / (np.linalg.norm(q_vec) + 1e-10)
         norms = np.linalg.norm(embeddings, axis=1, keepdims=True) + 1e-10
@@ -246,10 +268,19 @@ class RAGIndex:
         return [self._chunks[i] for i in top_indices]
 
     def _rerank(self, query: str, candidates: list[Chunk], top_n: int) -> list[Chunk]:
-        pairs = [[query, c.content] for c in candidates]
-        scores = self._reranker.compute_score(pairs, normalize=True)
-        ranked = sorted(zip(scores, candidates), reverse=True)
-        return [c for _, c in ranked[:top_n]]
+        if self.router and self.router.cfg.reranker == "cohere":
+            passages = [c.content for c in candidates]
+            scores = self.router.rerank(query, passages, top_n)
+            ranked = sorted(zip(scores, candidates, strict=True), reverse=True)
+            return [c for _, c in ranked[:top_n]]
+
+        if self._reranker:
+            pairs = [[query, c.content] for c in candidates]
+            scores = self._reranker.compute_score(pairs, normalize=True)
+            ranked = sorted(zip(scores, candidates, strict=True), reverse=True)
+            return [c for _, c in ranked[:top_n]]
+
+        return candidates[:top_n]
 
     def format_context(self, chunks: list[Chunk], max_chars: int = 8000) -> str:
         """Format retrieved chunks as context for LLM."""
@@ -271,6 +302,7 @@ class RAGIndex:
                 f.write(json.dumps(asdict(chunk)) + "\n")
 
         import numpy as np
+
         if self._embeddings:
             np.save(self.index_path / "embeddings.npy", np.array(self._embeddings))
 
@@ -298,6 +330,7 @@ class RAGIndex:
         if embeddings_file.exists():
             try:
                 import numpy as np
+
                 self._embeddings = np.load(embeddings_file).tolist()
             except Exception:
                 self._embeddings = []


### PR DESCRIPTION
Implements AGENT-3: RAG tuning fields (`AgentConfig` env defaults + persisted keys), `ProviderRouter.update_llm_url`, `get_sidebar_info`, `plan_with_documents` (Cohere grounded citations), Cohere rerank model override from optional `_agent_cfg`, and `RAGIndex.router`-aware Cohere rerank path.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hleserg/atman/pull/534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->