### PR TITLE
feat(agent-cli): file access, OCR, Telegram helpers (AGENT-4)

### DIFF
--- a/atman_agent_cli/src/atman/agent_cli/file_access.py
+++ b/atman_agent_cli/src/atman/agent_cli/file_access.py
@@ -1,0 +1,108 @@
+"""
+atman/agent_cli/file_access.py
+Safe filesystem access: read broadly; mutate only inside repo_root.
+
+CLI Integration Notes:
+  At startup use: repo_root, work_dir = SafeFileExplorer.get_work_dir()
+  Show in TUI header: atman-agent — {work_dir.name} — {branch}
+  Command /pwd → show work_dir and repo_root.
+  If agent calls write() outside repo → catch PermissionError → warn + prompt [y/N].
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+
+class PermissionError(Exception):
+    """Raised when a mutating operation is denied (outside repo or unconfirmed exec)."""
+
+
+class SafeFileExplorer:
+    """
+    Read anywhere. Write/delete/execute only inside repo_root.
+    Outside repo — read-only.
+    """
+
+    def __init__(self, repo_root: Path, work_dir: Path) -> None:
+        self.repo_root = repo_root.resolve()
+        self.work_dir = work_dir.resolve()
+
+    def read(self, path: str | Path) -> str:
+        """Read any file. Auto OCR for raster images."""
+        p = Path(path).resolve()
+        if p.suffix.lower() in (".jpg", ".jpeg", ".png", ".webp", ".gif", ".bmp"):
+            from .ocr import OCRProcessor
+
+            return OCRProcessor().extract_text(p)
+        if p.suffix.lower() == ".pdf":
+            return self._read_pdf(p)
+        return p.read_text(encoding="utf-8", errors="replace")
+
+    def _read_pdf(self, path: Path) -> str:
+        try:
+            from pdfminer.high_level import extract_text
+
+            return extract_text(str(path))
+        except ImportError:
+            return "[PDF reading requires: pip install pdfminer.six]"
+
+    def list_dir(self, path: Path | str) -> list[Path]:
+        """List directory entries."""
+        return list(Path(path).iterdir())
+
+    def search(
+        self, pattern: str, root: Path | str | None = None, recursive: bool = True
+    ) -> list[Path]:
+        """Find files matching a glob pattern."""
+        root_path = Path(root or self.work_dir)
+        if recursive:
+            return list(root_path.rglob(pattern))
+        return list(root_path.glob(pattern))
+
+    def write(self, path: Path | str, content: str) -> None:
+        """Write only inside repo_root."""
+        p = Path(path).resolve()
+        if not p.is_relative_to(self.repo_root):
+            raise PermissionError(f"Write outside repo is forbidden: {p}")
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+
+    def delete(self, path: Path | str) -> None:
+        """Delete only inside repo_root."""
+        p = Path(path).resolve()
+        if not p.is_relative_to(self.repo_root):
+            raise PermissionError(f"Delete outside repo is forbidden: {p}")
+        p.unlink()
+
+    def execute(self, cmd: str, confirm_callback: Callable[[], bool] | None = None) -> str:
+        """
+        Run a shell command only with explicit confirmation.
+        confirm_callback: callable() -> bool. If None — always refuse.
+        """
+        if confirm_callback is None or not confirm_callback():
+            raise PermissionError("Execution requires explicit user confirmation")
+        result = subprocess.run(cmd, shell=True, capture_output=True, text=True, check=False)
+        return result.stdout + result.stderr
+
+    @staticmethod
+    def find_git_root(start: Path) -> Path | None:
+        """Find git repository root starting from start."""
+        current = start.resolve()
+        while current != current.parent:
+            if (current / ".git").exists():
+                return current
+            current = current.parent
+        return None
+
+    @staticmethod
+    def get_work_dir() -> tuple[Path, Path]:
+        """
+        Return (repo_root, work_dir).
+        repo_root = git root or cwd if not in a git repo.
+        """
+        work_dir = Path.cwd()
+        repo_root = SafeFileExplorer.find_git_root(work_dir) or work_dir
+        return repo_root, work_dir

--- a/atman_agent_cli/src/atman/agent_cli/ocr.py
+++ b/atman_agent_cli/src/atman/agent_cli/ocr.py
@@ -1,0 +1,76 @@
+"""
+atman/agent_cli/ocr.py
+Image text extraction via easyocr with pytesseract fallback.
+
+CLI Integration Notes:
+  Wired from SafeFileExplorer.read() via image extension detection.
+  In Telegram handlers: OCRProcessor().extract_text(saved_path) for photos → chat text.
+  Folder ~/.atman/telegram/media/ — add to .gitignore when first used in production flows.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+class OCRProcessor:
+    """
+    Primary engine: easyocr (better for photos, supports RU).
+    Fallback: pytesseract (faster for clean screenshots; needs system tesseract).
+    """
+
+    def __init__(self, languages: list[str] | None = None) -> None:
+        self.languages = languages or ["ru", "en"]
+        self._reader: Any = None
+
+    def _get_reader(self) -> Any:
+        if self._reader is None:
+            import easyocr
+
+            try:
+                import torch
+
+                gpu = torch.cuda.is_available()
+            except ImportError:
+                gpu = False
+            self._reader = easyocr.Reader(self.languages, gpu=gpu)
+        return self._reader
+
+    def extract_text(self, image_path: Path) -> str:
+        """Extract text from an image with automatic backend selection."""
+        try:
+            reader = self._get_reader()
+            results = reader.readtext(str(image_path), detail=0)
+            text = "\n".join(results)
+            if len(text.strip()) < 10:
+                return self._tesseract_fallback(image_path) or text
+            return text
+        except ImportError:
+            return self._tesseract_fallback(image_path) or "[OCR unavailable: pip install easyocr]"
+
+    def _tesseract_fallback(self, image_path: Path) -> str | None:
+        try:
+            import pytesseract
+            from PIL import Image
+
+            lang = "+".join({"ru": "rus", "en": "eng"}.get(code, code) for code in self.languages)
+            return pytesseract.image_to_string(Image.open(image_path), lang=lang)
+        except (ImportError, OSError, ValueError, RuntimeError):
+            return None
+
+    def is_available(self) -> bool:
+        """Return True if at least one OCR backend import succeeds."""
+        try:
+            import easyocr  # noqa: F401
+
+            return True
+        except ImportError:
+            pass
+        try:
+            import pytesseract  # noqa: F401
+
+            return True
+        except ImportError:
+            pass
+        return False

--- a/atman_agent_cli/src/atman/agent_cli/telegram.py
+++ b/atman_agent_cli/src/atman/agent_cli/telegram.py
@@ -1,0 +1,135 @@
+"""
+atman/agent_cli/telegram.py
+Telegram bot for receiving tasks and files (python-telegram-bot v21+, async).
+
+CLI Integration Notes:
+  If config exposes a token, construct in cli.py:
+    self.telegram = TelegramBot(
+        token=secrets.get('telegram_token'),
+        allowed_ids=config.telegram_allowed_ids,
+        on_message=lambda text, cid: self.call_from_thread(self._inject_telegram_message, text),
+        on_file=lambda path, mime, cid: self.call_from_thread(self._notify_file_received, path),
+    )
+    asyncio.create_task(self.telegram.start())
+  On /quit: await self.telegram.stop()
+  Bot commands to add later: /status (agent status), /stop (stop executor)
+  Add ~/.atman/telegram/media/ to project .gitignore when enabling downloads.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+logger = logging.getLogger(__name__)
+
+MEDIA_DIR = Path.home() / ".atman" / "telegram" / "media"
+
+OnMessageCallback = Callable[[str, int], Awaitable[None]]
+OnFileCallback = Callable[[Path, str, int], Awaitable[None]]
+
+
+class TelegramBot:
+    """
+    Bot for receiving tasks and files from Telegram.
+    Intended to run alongside the TUI via an asyncio task.
+    Only authorized chat_ids are accepted.
+    """
+
+    def __init__(
+        self,
+        token: str,
+        allowed_ids: list[int],
+        on_message: OnMessageCallback,
+        on_file: OnFileCallback,
+    ) -> None:
+        self.token = token
+        self.allowed_ids = set(allowed_ids)
+        self.on_message = on_message
+        self.on_file = on_file
+        self._app: Any = None
+
+    def _is_allowed(self, chat_id: int) -> bool:
+        return chat_id in self.allowed_ids
+
+    async def start(self) -> None:
+        from telegram.ext import Application, MessageHandler, filters
+
+        self._app = Application.builder().token(self.token).build()
+        self._app.add_handler(MessageHandler(filters.TEXT, self._handle_text))
+        self._app.add_handler(MessageHandler(filters.PHOTO, self._handle_photo))
+        self._app.add_handler(MessageHandler(filters.Document.ALL, self._handle_document))
+
+        MEDIA_DIR.mkdir(parents=True, exist_ok=True)
+
+        await self._app.initialize()
+        await self._app.start()
+        await self._app.updater.start_polling()
+        logger.info("Telegram bot started")
+
+    async def stop(self) -> None:
+        if self._app:
+            await self._app.updater.stop()
+            await self._app.stop()
+            await self._app.shutdown()
+            self._app = None
+
+    async def send(self, chat_id: int, text: str) -> None:
+        if self._app:
+            await self._app.bot.send_message(chat_id=chat_id, text=text)
+
+    async def _handle_text(self, update: Any, context: Any) -> None:
+        if update.effective_chat is None or update.message is None:
+            return
+        chat_id = update.effective_chat.id
+        if not self._is_allowed(chat_id):
+            return
+        text = update.message.text or ""
+        await self.on_message(text, chat_id)
+
+    async def _handle_photo(self, update: Any, context: Any) -> None:
+        if update.effective_chat is None or update.message is None or not update.message.photo:
+            return
+        chat_id = update.effective_chat.id
+        if not self._is_allowed(chat_id):
+            return
+        photo = update.message.photo[-1]
+        file = await context.bot.get_file(photo.file_id)
+        path = MEDIA_DIR / f"{uuid4()}.jpg"
+        await file.download_to_drive(str(path))
+
+        try:
+            from .ocr import OCRProcessor
+
+            text = OCRProcessor().extract_text(path)
+            await self.on_message(f"[Photo OCR]\n{text}", chat_id)
+        except Exception as e:
+            logger.warning("OCR failed: %s", e)
+            await self.on_file(path, "image/jpeg", chat_id)
+
+    async def _handle_document(self, update: Any, context: Any) -> None:
+        if (
+            update.effective_chat is None
+            or update.message is None
+            or update.message.document is None
+        ):
+            return
+        chat_id = update.effective_chat.id
+        if not self._is_allowed(chat_id):
+            return
+        doc = update.message.document
+        file = await context.bot.get_file(doc.file_id)
+        suffix = Path(doc.file_name or "file").suffix
+        path = MEDIA_DIR / f"{uuid4()}{suffix}"
+        await file.download_to_drive(str(path))
+
+        if suffix.lower() == ".pdf":
+            from .file_access import SafeFileExplorer
+
+            text = SafeFileExplorer(path.parent, path.parent).read(path)
+            await self.on_message(f"[PDF Content]\n{text[:3000]}", chat_id)
+        else:
+            await self.on_file(path, doc.mime_type or "application/octet-stream", chat_id)


### PR DESCRIPTION
## Summary
Implements AGENT-4 scoped modules under `atman_agent_cli/src/atman/agent_cli/` only (does not edit `cli.py` per instructions).

### `file_access.py`
- `SafeFileExplorer`: read-anywhere policy; writes/deletes restricted to resolved `repo_root`; shell `execute()` gated by confirmation callback (default denies).
- Image reads delegate to OCR; PDF reads use optional `pdfminer.six`.
- Helpers: `find_git_root`, `get_work_dir`.
- Uses project-local `PermissionError` for policy failures (CLI should catch explicitly).

### `ocr.py`
- `OCRProcessor`: lazy `easyocr.Reader` with optional CUDA via `torch`; short-text path tries `pytesseract` + PIL; `is_available()` for capability checks.

### `telegram.py`
- `TelegramBot` (PTB ≥21 async): TEXT / PHOTO / DOCUMENT handlers; whitelist `allowed_ids`; downloads to `~/.atman/telegram/media/`; photos run OCR then `on_message`; PDFs inlined via `SafeFileExplorer.read` (truncated in message).
- **`on_message` / `on_file` must be async callables** (handlers use `await`).

CLI wiring is documented in module docstrings (TASK integration notes).

## Verification
- `ruff check` / `ruff format` on the three new modules.


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hleserg/atman/pull/535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->