### PR TITLE
feat(reflection): R4 — DeepReflectionService on SessionRepository

### DIFF
--- a/docs/architecture/SYSTEM_MAP-ru.md
+++ b/docs/architecture/SYSTEM_MAP-ru.md
@@ -244,7 +244,7 @@
 | `request_reflection` ↔ `ReflectionRequestQueue` | `adapters/agent/tools.py` → `core/ports/reflection_request_queue.py` | **R12** инструмент регистрируется только при наличии очереди в `AtmanDeps`; идемпотентность через `agent_driven_run_key` (UTC hour bucket) |
 | `MicroReflectionService` ↔ `ExperienceRepository` + `NarrativeRepository` | `core/services/reflection_service.py` | чтение опыта, апдейт recent-слоя |
 | `DailyReflectionService` ↔ `SessionRepository` + `PatternStore` + `ReflectionEventStore` | `core/services/reflection_service.py` | детекция паттернов (R3 — мигрирован с `ExperienceRepository`; синтезирует виртуальные `SessionExperience` через `services/session_experience_view.build_session_experience`) |
-| `DeepReflectionService` ↔ все рефлексионные порты | `core/services/reflection_service.py` | здоровье + апдейт identity и нарратива |
+| `DeepReflectionService` ↔ `SessionRepository` + `IdentityRepository` + `NarrativeRepository` + `PatternStore` + `HealthAssessmentStore` + `ReflectionEventStore` | `core/services/reflection_service.py` | здоровье + апдейт identity и нарратива (R4 — мигрирован с `ExperienceRepository`; синтезирует виртуальные `SessionExperience` через `services/session_experience_view.build_session_experience`) |
 | `PrincipleRevisionAdvisor` ↔ `PatternCandidate` + `Identity` | `core/services/principle_advisor.py` | анализ паттернов в контексте identity |
 
 ### 2.2. Адаптер ↔ порт
@@ -320,7 +320,7 @@ DailyReflectionService — читает сессии + key moments через Se
   ↓ сохраняет
 PatternStore + ReflectionEventStore
   ↓
-DeepReflectionService — читает все репозитории, оценивает здоровье,
+DeepReflectionService — читает сессии + key moments через SessionRepository, оценивает здоровье,
   обновляет identity и нарратив (с governance)
   ↓ предлагает
 PrincipleRevisionAdvisor — пересмотр принципов

--- a/docs/architecture/SYSTEM_MAP.md
+++ b/docs/architecture/SYSTEM_MAP.md
@@ -240,7 +240,7 @@ Connections between two or more parts. These are seams that may break independen
 | `request_reflection` ↔ `ReflectionRequestQueue` | `adapters/agent/tools.py` → `core/ports/reflection_request_queue.py` | **R12** tool registered only when queue is in `AtmanDeps`; idempotent via `agent_driven_run_key` (UTC hour bucket) |
 | `MicroReflectionService` ↔ `ExperienceRepository` + `NarrativeRepository` | `core/services/reflection_service.py` | reads experience, updates recent layer |
 | `DailyReflectionService` ↔ `SessionRepository` + `PatternStore` + `ReflectionEventStore` | `core/services/reflection_service.py` | pattern detection (R3 — migrated off `ExperienceRepository`; synthesises virtual `SessionExperience` via `services/session_experience_view.build_session_experience`) |
-| `DeepReflectionService` ↔ all reflection ports | `core/services/reflection_service.py` | health + identity + narrative update |
+| `DeepReflectionService` ↔ `SessionRepository` + `IdentityRepository` + `NarrativeRepository` + `PatternStore` + `HealthAssessmentStore` + `ReflectionEventStore` | `core/services/reflection_service.py` | health + identity + narrative update (R4 — migrated off `ExperienceRepository`; synthesises virtual `SessionExperience` via `services/session_experience_view.build_session_experience`) |
 | `PrincipleRevisionAdvisor` ↔ `PatternCandidate` + `Identity` | `core/services/principle_advisor.py` | analyzes patterns in identity context |
 | `ConflictDetector` ↔ `FactualMemory` | `core/services/conflict_detector.py` → `core/ports/memory_backend.py` | DI; lightweight contradiction scan over ACTIVE candidates returned by `search()` |
 | `EmotionalEcho` ↔ `StateStore` | `core/services/emotional_echo.py` → `core/ports/state_store.py` | DI; `lookback_days` window via `search_experiences` |
@@ -322,7 +322,7 @@ DailyReflectionService — reads sessions + key moments via SessionRepository fo
   ↓ stores
 PatternStore + ReflectionEventStore
   ↓
-DeepReflectionService — reads all repositories, assesses health,
+DeepReflectionService — reads sessions + key moments via SessionRepository, assesses health,
   updates identity and narrative (with governance)
   ↓ proposes
 PrincipleRevisionAdvisor — principle revision

--- a/e2e/full_loop.py
+++ b/e2e/full_loop.py
@@ -641,7 +641,7 @@ def _run_e2e_loop(workspace_path: Path) -> int:
     health_store = InMemoryHealthAssessmentStore()
 
     deep_service = DeepReflectionService(
-        experience_repo=experience_repo,
+        session_repo=session_repo,
         identity_repo=identity_repo,
         narrative_repo=narrative_repo,
         pattern_store=pattern_store,

--- a/src/atman/cli_reflection.py
+++ b/src/atman/cli_reflection.py
@@ -391,7 +391,7 @@ def cmd_reflect_deep(args: list[str]) -> int:
     event_store = InMemoryReflectionEventStore()
 
     service = DeepReflectionService(
-        experience_repo=experience_repo,
+        session_repo=experience_repo,
         identity_repo=identity_repo,
         narrative_repo=narrative_repo,
         pattern_store=pattern_store,

--- a/src/atman/core/services/reflection_service.py
+++ b/src/atman/core/services/reflection_service.py
@@ -499,7 +499,7 @@ class DeepReflectionService:
 
     def __init__(
         self,
-        experience_repo: ExperienceRepository,
+        session_repo: SessionRepository,
         identity_repo: IdentityRepository,
         narrative_repo: NarrativeRepository,
         pattern_store: PatternStore,
@@ -511,7 +511,7 @@ class DeepReflectionService:
         reflection_event_observer: ReflectionEventPersistenceObserver | None = None,
     ):
         """Initialize deep reflection service."""
-        self.experience_repo = experience_repo
+        self.session_repo = session_repo
         self.identity_repo = identity_repo
         self.narrative_repo = narrative_repo
         self.pattern_store = pattern_store
@@ -536,7 +536,13 @@ class DeepReflectionService:
         """
         since_utc = ensure_utc(since)
         until_utc = ensure_utc(until)
-        experiences = self.experience_repo.get_in_range(since_utc, until_utc)
+        sessions = self.session_repo.get_sessions_in_range(since_utc, until_utc)
+        experiences: list[SessionExperience] = []
+        for s in sessions:
+            moments = self.session_repo.get_key_moments_for_session(s.id)
+            if not moments:
+                continue
+            experiences.append(build_session_experience(s, moments))
 
         if not experiences:
             return self._create_empty_event(since_utc, until_utc)
@@ -732,7 +738,7 @@ class DeepReflectionService:
                     reflection_type=reframing_out.reflection_type,
                     triggered_by=reframing_trigger_key(run_key, exp.id),
                 )
-                outcome = self.experience_repo.add_reframing_note(exp.id, note)
+                outcome = self.session_repo.add_reframing_note(exp.id, note)
                 if outcome == ReframingNoteAppendResult.STORED:
                     count += 1
                 elif outcome == ReframingNoteAppendResult.EXPERIENCE_NOT_FOUND:

--- a/src/demo_full_corpus.py
+++ b/src/demo_full_corpus.py
@@ -123,7 +123,7 @@ def _reflection_bundle(
         clock=clock,
     )
     deep = DeepReflectionService(
-        experience_repo=experience_repo,
+        session_repo=session_repo,
         identity_repo=identity_repo,
         narrative_repo=narrative_repo,
         pattern_store=pattern_store,

--- a/src/demo_reflection.py
+++ b/src/demo_reflection.py
@@ -391,7 +391,7 @@ def demo_deep_reflection(
     event_store = InMemoryReflectionEventStore()
 
     service = DeepReflectionService(
-        experience_repo=exp_repo,
+        session_repo=exp_repo,
         identity_repo=identity_repo,
         narrative_repo=narrative_repo,
         pattern_store=pattern_store,

--- a/tests/test_reflection_services.py
+++ b/tests/test_reflection_services.py
@@ -761,7 +761,7 @@ def test_deep_reflection_performs_health_assessment() -> None:
     event_store = InMemoryReflectionEventStore()
 
     service = DeepReflectionService(
-        experience_repo=exp_repo,
+        session_repo=exp_repo,
         identity_repo=identity_repo,
         narrative_repo=narrative_repo,
         pattern_store=pattern_store,
@@ -808,7 +808,7 @@ def test_deep_reflection_proposes_changes() -> None:
     event_store = InMemoryReflectionEventStore()
 
     service = DeepReflectionService(
-        experience_repo=exp_repo,
+        session_repo=exp_repo,
         identity_repo=identity_repo,
         narrative_repo=narrative_repo,
         pattern_store=pattern_store,
@@ -854,7 +854,7 @@ def test_deep_reflection_promotes_structured_pattern_implications() -> None:
         reframing_text="Strategic reframing note",
     )
     service = DeepReflectionService(
-        experience_repo=exp_repo,
+        session_repo=exp_repo,
         identity_repo=identity_repo,
         narrative_repo=narrative_repo,
         pattern_store=pattern_store,
@@ -896,7 +896,7 @@ def test_deep_reflection_fixture_json_adds_reframing() -> None:
     event_store = InMemoryReflectionEventStore()
 
     service = DeepReflectionService(
-        experience_repo=exp_repo,
+        session_repo=exp_repo,
         identity_repo=identity_repo,
         narrative_repo=narrative_repo,
         pattern_store=pattern_store,
@@ -966,7 +966,7 @@ def test_deep_reflection_skipped_no_identity_preserves_experience_ids() -> None:
     event_store = InMemoryReflectionEventStore()
 
     service = DeepReflectionService(
-        experience_repo=exp_repo,
+        session_repo=exp_repo,
         identity_repo=identity_repo,
         narrative_repo=narrative_repo,
         pattern_store=pattern_store,
@@ -1010,7 +1010,7 @@ def test_deep_reflection_persist_failure_links_health_assessment() -> None:
     observer = _CapturingReflectionEventObserver()
 
     service = DeepReflectionService(
-        experience_repo=exp_repo,
+        session_repo=exp_repo,
         identity_repo=identity_repo,
         narrative_repo=narrative_repo,
         pattern_store=pattern_store,
@@ -1278,7 +1278,7 @@ def test_deep_empty_period_is_idempotent() -> None:
     event_store = InMemoryReflectionEventStore()
 
     service = DeepReflectionService(
-        experience_repo=exp_repo,
+        session_repo=exp_repo,
         identity_repo=identity_repo,
         narrative_repo=narrative_repo,
         pattern_store=pattern_store,
@@ -1392,7 +1392,7 @@ def test_deep_reflection_retry_after_event_save_failure_counts_duplicate_reframi
     observer = _CapturingReflectionEventObserver()
 
     service = DeepReflectionService(
-        experience_repo=exp_repo,
+        session_repo=exp_repo,
         identity_repo=identity_repo,
         narrative_repo=narrative_repo,
         pattern_store=pattern_store,
@@ -1495,7 +1495,7 @@ def test_deep_reflection_empty_window_is_idempotent() -> None:
     event_store = InMemoryReflectionEventStore()
 
     service = DeepReflectionService(
-        experience_repo=exp_repo,
+        session_repo=exp_repo,
         identity_repo=identity_repo,
         narrative_repo=narrative_repo,
         pattern_store=pattern_store,
@@ -1538,7 +1538,7 @@ def test_deep_reflection_no_identity_is_idempotent() -> None:
     event_store = InMemoryReflectionEventStore()
 
     service = DeepReflectionService(
-        experience_repo=exp_repo,
+        session_repo=exp_repo,
         identity_repo=identity_repo,
         narrative_repo=narrative_repo,
         pattern_store=pattern_store,
@@ -1579,7 +1579,7 @@ def test_deep_reflection_second_successful_run_is_idempotent() -> None:
     event_store = InMemoryReflectionEventStore()
 
     service = DeepReflectionService(
-        experience_repo=exp_repo,
+        session_repo=exp_repo,
         identity_repo=identity_repo,
         narrative_repo=narrative_repo,
         pattern_store=pattern_store,
@@ -1643,7 +1643,7 @@ def test_deep_reflection_repeated_run_does_not_duplicate_snapshot() -> None:
     event_store = InMemoryReflectionEventStore()
 
     service = DeepReflectionService(
-        experience_repo=exp_repo,
+        session_repo=exp_repo,
         identity_repo=identity_repo,
         narrative_repo=narrative_repo,
         pattern_store=pattern_store,

--- a/tests/test_system_e2e_lifecycle.py
+++ b/tests/test_system_e2e_lifecycle.py
@@ -334,7 +334,7 @@ def test_bootstrap_to_deep_reflection_full_lifecycle():
         until = today + timedelta(hours=12)
 
         deep = DeepReflectionService(
-            experience_repo=exp_repo,
+            session_repo=session_repo,
             identity_repo=identity_repo,
             narrative_repo=narrative_repo,
             pattern_store=pattern_store,


### PR DESCRIPTION
## Summary

R4 from `REFLECTION_FUTURE.md` §11 — mirrors the R3 migration that landed in #565 for the deep-level reflection service.

- `DeepReflectionService.__init__` now takes `session_repo: SessionRepository`
- `reflect(since, until)` pulls sessions via `get_sessions_in_range`, fetches per-session moments, and synthesises virtual `SessionExperience` inputs via `build_session_experience` so the existing `ReflectionModel` prompts keep working unchanged
- Reframing notes write through `session_repo.add_reframing_note` (which translates `session_id → deterministic_session_experience_id` at the storage boundary, see #565)

### Callers / fixtures updated
- `src/demo_reflection.py`, `src/atman/cli_reflection.py`: pass `MockExperienceRepo` (already has the `SessionRepository` surface from R3) as `session_repo`.
- `src/demo_full_corpus.py`, `e2e/full_loop.py`: pass the existing `StateStoreSessionRepository` as `session_repo`.
- `tests/test_reflection_services.py`: 12 `DeepReflectionService` instantiations renamed `experience_repo=` → `session_repo=`.
- `tests/test_system_e2e_lifecycle.py`: pass `session_repo` to Deep.

### SYSTEM_MAP
§2.1 integration row + §2.6 chain diagram (en + ru) updated for the new wiring.

## Out of scope
- **MicroReflectionService** stays on `ExperienceRepository` for now — operates on a single session and the `get_by_session()` shape needs a small Session-side helper before migrating.
- **R14** (delete `ExperienceViewRepository` compat adapter) follows after Micro is migrated or confirmed not to depend on it.
- **R5+** new aggregators (depend on a `ReflectionModel` port that consumes `(Session, moments)` directly).

## Test plan
- [x] `python -m pytest tests/` → 1603 passed, 138 skipped
- [x] `make lint` + `make typecheck` + `make security` + import-boundary contracts → clean

---
_Generated by [Claude Code](https://claude.ai/code/session_014aj6emXFWShAxmpvR2vXTA)_