### PR TITLE
fix(reflection): address PR #579 review issues — merge conflicts, missing adapter entry, missing type annotation

### DIFF
--- a/docs/architecture/SYSTEM_MAP-ru.md
+++ b/docs/architecture/SYSTEM_MAP-ru.md
@@ -273,12 +273,9 @@
 | `MicroReflectionService` ↔ `SessionRepository` + `NarrativeRepository` | `core/services/reflection_service.py` | читает одну сессию + её key moments, синтезирует виртуальный `SessionExperience` через `services/session_experience_view.build_session_experience`, апдейт recent-слоя (R-Micro — мигрирован с `ExperienceRepository`) |
 | `MicroReflectionService` ↔ `SkillManagerPort` | `core/services/reflection_service.py` | **WP-08 v2** опциональный хук: если `skill_manager` и `agent_id` заданы, вызывает `process_session_skills(agent_id, session_id)` после апдейта нарратива; ошибки подавляются, чтобы слой навыков не мог заблокировать рефлексию |
 | `DailyReflectionService` ↔ `SessionRepository` + `PatternStore` + `ReflectionEventStore` | `core/services/reflection_service.py` | детекция паттернов (R3 — мигрирован с `ExperienceRepository`; синтезирует виртуальные `SessionExperience` через `services/session_experience_view.build_session_experience`) |
-<<<<<<< HEAD
 | `DailyReflectionService` ↔ `StructuredMarkersAggregator` (R5) | `core/services/structured_markers_aggregator.py` | чистая агрегация над `KeyMoment.structured_markers`; ≥5 моментов с одинаковым `signal_type`/`signal_value` → daily `PatternCandidate` через `PatternStore.save_with_detection_key` (идемпотентно по `daily_marker_pattern_detection_key`) |
-=======
 | `DailyReflectionService` ↔ `DivergenceAggregator` (R6) | `core/services/divergence_aggregator.py` → `core/ports/divergence_events.py` (`DivergenceEventStore`) + `PatternStore` | опциональный хук; читает `divergence_events` за UTC-день (per-agent), группирует по `divergence_type` и пишет `PatternCandidate(BEHAVIOR)` для каждого типа с ≥ `min_count` (по умолчанию 3) событий (идемпотентно через `daily_divergence_pattern_detection_key`); любое событие `severity='rupture'` попадает в `ReflectionEvent.key_insight` независимо от порога |
 | `DailyReflectionService` ↔ `FindingsTriage` (R8) | `core/services/findings_triage.py` → `core/ports/memory_guardian.py` (`get_unresolved` / `resolve_finding`) | опциональный хук; резолвит уровень B (`info`/`warning`) `validation_findings` по правилам: `orphan_entity`→`ignored` (kept by policy), `pending_structured_markers`→`ignored` (accepted as-is), `analysis_failed`/`affect_detector_silent`→`requires_attention`, тривиальный `similar_entities` (cosine ≥ `DAILY_TRIVIAL_DUPLICATE_THRESHOLD=0.98`)→`ignored` (передаётся в Deep R10), нетривиальный `similar_entities`→остаётся unresolved для Deep R10. Critical-severity findings **никогда** не резолвятся автоматически здесь |
->>>>>>> cc46837 (feat(reflection): R6 DivergenceAggregator + R8 FindingsTriage (daily))
 | `DeepReflectionService` ↔ `SessionRepository` + `IdentityRepository` + `NarrativeRepository` + `PatternStore` + `HealthAssessmentStore` + `ReflectionEventStore` | `core/services/reflection_service.py` | здоровье + апдейт identity и нарратива (R4 — мигрирован с `ExperienceRepository`; синтезирует виртуальные `SessionExperience` через `services/session_experience_view.build_session_experience`) |
 | `PrincipleRevisionAdvisor` ↔ `PatternCandidate` + `Identity` | `core/services/principle_advisor.py` | анализ паттернов в контексте identity |
 | `ConflictDetector` ↔ `FactualMemory` | `core/services/conflict_detector.py` → `core/ports/memory_backend.py` | DI; лёгкий поиск противоречий среди ACTIVE-кандидатов, возвращённых `search()` |
@@ -309,6 +306,7 @@
 | `StateStoreSessionRepository` (`adapters/reflection/`) | `SessionRepository` (R1 — преемник ExperienceRepository) |
 | `InMemorySkillStore` (`skills/in_memory_store.py`), `PostgresSkillStore` (`skills/postgres_store.py`) | `SkillStore` (WP-08 v2) |
 | `NoopSkillManager` (`skills/noop.py`), `SkillManager` (`skills/manager.py`) | `SkillManagerPort` (WP-08 v2) |
+| `InMemoryDivergenceEventStore` (`adapters/memory/in_memory_divergence_events.py`) | `DivergenceEventStore` (R6) |
 
 ### 2.2a. Agent adapter ↔ сервисы
 

--- a/docs/architecture/SYSTEM_MAP.md
+++ b/docs/architecture/SYSTEM_MAP.md
@@ -269,12 +269,9 @@ Connections between two or more parts. These are seams that may break independen
 | `MicroReflectionService` ↔ `SessionRepository` + `NarrativeRepository` | `core/services/reflection_service.py` | reads one session + its key moments, synthesises a virtual `SessionExperience` via `services/session_experience_view.build_session_experience`, updates recent layer (R-Micro — migrated off `ExperienceRepository`) |
 | `MicroReflectionService` ↔ `SkillManagerPort` | `core/services/reflection_service.py` | **WP-08 v2** optional hook: if `skill_manager` and `agent_id` are set, calls `process_session_skills(agent_id, session_id)` after narrative update; errors suppressed so reflection cannot be blocked by skill failures |
 | `DailyReflectionService` ↔ `SessionRepository` + `PatternStore` + `ReflectionEventStore` | `core/services/reflection_service.py` | pattern detection (R3 — migrated off `ExperienceRepository`; synthesises virtual `SessionExperience` via `services/session_experience_view.build_session_experience`) |
-<<<<<<< HEAD
 | `DailyReflectionService` ↔ `StructuredMarkersAggregator` (R5) | `core/services/structured_markers_aggregator.py` | pure aggregation over `KeyMoment.structured_markers`; ≥5 moments sharing a `signal_type`/`signal_value` → daily `PatternCandidate` persisted via `PatternStore.save_with_detection_key` (idempotent per `daily_marker_pattern_detection_key`) |
-=======
 | `DailyReflectionService` ↔ `DivergenceAggregator` (R6) | `core/services/divergence_aggregator.py` → `core/ports/divergence_events.py` (`DivergenceEventStore`) + `PatternStore` | optional hook; reads `divergence_events` for the UTC day (per-agent), groups by `divergence_type` and emits a `PatternCandidate(BEHAVIOR)` per type with ≥ `min_count` (default 3) events (idempotent via `daily_divergence_pattern_detection_key`); any `severity='rupture'` event surfaces in `ReflectionEvent.key_insight` regardless of the per-type threshold |
 | `DailyReflectionService` ↔ `FindingsTriage` (R8) | `core/services/findings_triage.py` → `core/ports/memory_guardian.py` (`get_unresolved` / `resolve_finding`) | optional hook; resolves level-B (`info`/`warning`) `validation_findings` by policy: `orphan_entity`→`ignored` (kept by policy), `pending_structured_markers`→`ignored` (accepted as-is), `analysis_failed`/`affect_detector_silent`→`requires_attention`, trivial `similar_entities` (cosine ≥ `DAILY_TRIVIAL_DUPLICATE_THRESHOLD=0.98`)→`ignored` (deferred to Deep R10), non-trivial `similar_entities`→left unresolved for Deep R10. Critical-severity findings are **never** auto-resolved here |
->>>>>>> cc46837 (feat(reflection): R6 DivergenceAggregator + R8 FindingsTriage (daily))
 | `DeepReflectionService` ↔ `SessionRepository` + `IdentityRepository` + `NarrativeRepository` + `PatternStore` + `HealthAssessmentStore` + `ReflectionEventStore` | `core/services/reflection_service.py` | health + identity + narrative update (R4 — migrated off `ExperienceRepository`; synthesises virtual `SessionExperience` via `services/session_experience_view.build_session_experience`) |
 | `PrincipleRevisionAdvisor` ↔ `PatternCandidate` + `Identity` | `core/services/principle_advisor.py` | analyzes patterns in identity context |
 | `ConflictDetector` ↔ `FactualMemory` | `core/services/conflict_detector.py` → `core/ports/memory_backend.py` | DI; lightweight contradiction scan over ACTIVE candidates returned by `search()` |
@@ -305,6 +302,7 @@ Connections between two or more parts. These are seams that may break independen
 | `StateStoreSessionRepository` (`adapters/reflection/`) | `SessionRepository` (R1 — successor to ExperienceRepository) |
 | `InMemorySkillStore` (`skills/in_memory_store.py`), `PostgresSkillStore` (`skills/postgres_store.py`) | `SkillStore` (WP-08 v2) |
 | `NoopSkillManager` (`skills/noop.py`), `SkillManager` (`skills/manager.py`) | `SkillManagerPort` (WP-08 v2) |
+| `InMemoryDivergenceEventStore` (`adapters/memory/in_memory_divergence_events.py`) | `DivergenceEventStore` (R6) |
 
 ### 2.2a. Agent adapter ↔ services
 

--- a/src/atman/core/services/reflection_service.py
+++ b/src/atman/core/services/reflection_service.py
@@ -55,7 +55,7 @@ from atman.core.reflection_run_keys import (
     reframing_trigger_key,
 )
 from atman.core.services.divergence_aggregator import DivergenceAggregator
-from atman.core.services.findings_triage import FindingsTriage
+from atman.core.services.findings_triage import FindingsTriage, TriageOutcome
 from atman.core.services.narrative_revision import NarrativeRevisionService
 from atman.core.services.session_experience_view import build_session_experience
 from atman.core.services.structured_markers_aggregator import StructuredMarkersAggregator
@@ -508,7 +508,7 @@ class DailyReflectionService:
             agent_id=self._agent_id, start=start, end=end, run_key=run_key
         )
 
-    def _triage_findings(self):
+    def _triage_findings(self) -> TriageOutcome | None:
         """R8 hook. Returns TriageOutcome or None when no triage is wired."""
         if self._findings_triage is None or self._agent_id is None:
             return None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## PLAYBOOK markers

- [x] I introduced no generalizable patterns (pure refactoring / project-specific changes)

---

## Что сделано

PR #579 был случайно смерджен до того как ревьюер Devin успел оставить комментарии. Devin нашёл 4 проблемы — все исправлены в этом PR.

**Исправления:**

1. **Merge conflict markers в `SYSTEM_MAP.md` (lines 272–277)** — в файл попали нерезолвленные маркеры `<<<<<<< HEAD` / `=======` / `>>>>>>>`. Строка R5 (`StructuredMarkersAggregator`) из HEAD конфликтовала с новыми строками R6 и R8 из feature-ветки. Корректное разрешение: сохранить все три строки (R5, R6, R8).

2. **Merge conflict markers в `SYSTEM_MAP-ru.md` (lines 276–281)** — та же проблема в русской версии файла, разрешена аналогично.

3. **Отсутствующая запись адаптера в §2.2** — PR #579 добавил новый порт `DivergenceEventStore` (`core/ports/divergence_events.py`) и его in-memory адаптер `InMemoryDivergenceEventStore` (`adapters/memory/in_memory_divergence_events.py`), но таблица §2.2 в обоих файлах (EN и RU) не содержала соответствующей строки. Добавлена строка `InMemoryDivergenceEventStore` ↔ `DivergenceEventStore` (R6).

4. **Отсутствующая аннотация типа на `_triage_findings`** — метод `_triage_findings(self):` в `reflection_service.py:511` не имел аннотации возвращаемого типа (в нарушение правила «все функции должны иметь аннотации типов»). Добавлена аннотация `-> TriageOutcome | None` и `TriageOutcome` добавлен в import.

## Как воспроизвести (демонстрация)

**N/A** — изменения не меняют поведение для пользователя, только исправляют документацию и type annotation в коде.

Проверка отсутствия конфликтов:
```bash
grep -n "<<<<<<\|=======\|>>>>>>>" docs/architecture/SYSTEM_MAP.md docs/architecture/SYSTEM_MAP-ru.md
# Должно вернуть пустой результат
```

Проверка type annotation:
```bash
pyright src/atman/core/services/reflection_service.py
```

## Тип изменений

- [x] Исправление ошибки

## Карта системы

- **Затронутые разделы карты:** §2.1 — восстановлены строки R5/R6/R8 (нерезолвленный конфликт); §2.2 — добавлена строка `InMemoryDivergenceEventStore` ↔ `DivergenceEventStore`
- **Покрытие тестами:** `tests/test_divergence_aggregator.py`, `tests/test_findings_triage.py`, `tests/test_daily_reflection_with_aggregators.py` — покрывают R6/R8 функциональность (добавлены в #579)
- **Закрытые GAP'ы из §4.5:** N/A
- **Карта обновлена:** [x] `docs/architecture/SYSTEM_MAP.md` + [x] `SYSTEM_MAP-ru.md`

## Тесты-страховки агентной разработки

**N/A** — не изменены порты, адаптеры, персистируемые модели, CLI-команды или бизнес-инварианты.

## Чеклист

- [x] Описание соответствует фактическим изменениям
- [x] При необходимости обновлены `docs/architecture/SYSTEM_MAP.md` и `SYSTEM_MAP-ru.md`
- [x] `ruff check src/ tests/` — 0 новых ошибок (2 pre-existing UP038 в `bge_reranker.py` и `structured_markers_aggregator.py`, существуют в main)
- [x] `ruff format --check src/ tests/` — 0 ошибок
- [x] `pyright src/ tests/` — 95 ошибок (все pre-existing missing imports; наш PR счётчик не увеличил)
- [x] `bandit -c pyproject.toml -r src/atman/` — 0 ошибок
- [x] `pytest tests/ -v --cov=atman --cov-fail-under=90` — 1739 passed, 138 skipped; coverage 90.66% ≥ 90%

## Примечания

Этот PR исправляет только замечания ревьюера Devin из PR #579, который был смерджен раньше времени. Функциональных изменений нет.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62447d89-a428-4a3a-9dd0-0d917984e0f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62447d89-a428-4a3a-9dd0-0d917984e0f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hleserg/atman/pull/583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->