### PR TITLE
docs(readme): update test count to 1764 passing / 138 skipped

### DIFF
--- a/README-ru.md
+++ b/README-ru.md
@@ -65,7 +65,7 @@ Atman - это инфраструктура с открытым исходным
   ├─ Identity Store     ✅ Реализовано (WP03)
   ├─ Reflection Engine  ✅ Реализовано (WP04)
   ├─ Session Manager    ✅ Реализовано (WP05)
-  └─ CI и покрытие тестами ✅ GitHub Actions для `main`/PR (`make check`, pytest-cov ≥89%)
+  └─ CI и покрытие тестами ✅ GitHub Actions для `main`/PR (`make check`, pytest-cov ≥90%)
 ○ Первая реализация
 ○ Интеграция
 ○ Развитие

--- a/README-ru.md
+++ b/README-ru.md
@@ -8,7 +8,7 @@
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
-**Тесты:** 568 проходят (`pytest tests/` на `main`; см. workflow CI выше).
+**Тесты:** 1764 проходят, 138 пропущены (`pytest tests/` на `main`; см. workflow CI выше).
 
 [[en](README.md)] — *English version*
 
@@ -65,7 +65,7 @@ Atman - это инфраструктура с открытым исходным
   ├─ Identity Store     ✅ Реализовано (WP03)
   ├─ Reflection Engine  ✅ Реализовано (WP04)
   ├─ Session Manager    ✅ Реализовано (WP05)
-  └─ CI и покрытие тестами ✅ GitHub Actions для `main`/PR (`make check`, pytest-cov ≥90%)
+  └─ CI и покрытие тестами ✅ GitHub Actions для `main`/PR (`make check`, pytest-cov ≥89%)
 ○ Первая реализация
 ○ Интеграция
 ○ Развитие

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Under the hood — seven components: store of lived experiences, reflection engi
   ├─ Identity Store     ✅ Implemented (WP03)
   ├─ Reflection Engine  ✅ Implemented (WP04)
   ├─ Session Manager    ✅ Implemented (WP05)
-  └─ CI & test coverage ✅ GitHub Actions on `main`/PRs (`make check`, pytest-cov ≥89%)
+  └─ CI & test coverage ✅ GitHub Actions on `main`/PRs (`make check`, pytest-cov ≥90%)
 ○ First implementation
 ○ Integration
 ○ Evolution

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
-**Tests:** 568 passing (`pytest tests/` on `main`; see CI workflow above).
+**Tests:** 1764 passing, 138 skipped (`pytest tests/` on `main`; see CI workflow above).
 
 [[ru](README-ru.md)] — *Russian version*
 
@@ -65,7 +65,7 @@ Under the hood — seven components: store of lived experiences, reflection engi
   ├─ Identity Store     ✅ Implemented (WP03)
   ├─ Reflection Engine  ✅ Implemented (WP04)
   ├─ Session Manager    ✅ Implemented (WP05)
-  └─ CI & test coverage ✅ GitHub Actions on `main`/PRs (`make check`, pytest-cov ≥90%)
+  └─ CI & test coverage ✅ GitHub Actions on `main`/PRs (`make check`, pytest-cov ≥89%)
 ○ First implementation
 ○ Integration
 ○ Evolution

--- a/docs/content/README-ru.md
+++ b/docs/content/README-ru.md
@@ -8,7 +8,7 @@
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
-**Тесты:** 568 проходят (`pytest tests/` на `main`; см. workflow CI выше).
+**Тесты:** 1764 проходят, 138 пропущены (`pytest tests/` на `main`; см. workflow CI выше).
 
 [[en](README.md)] — *English version*
 

--- a/docs/content/README.md
+++ b/docs/content/README.md
@@ -8,7 +8,7 @@
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
-**Tests:** 568 passing (`pytest tests/` on `main`; see CI workflow above).
+**Tests:** 1764 passing, 138 skipped (`pytest tests/` on `main`; see CI workflow above).
 
 [[ru](README-ru.md)] — *Russian version*
 


### PR DESCRIPTION
## Summary

The README claimed **568 passing tests** — actual count is **1764 passing, 138 skipped** (1902 collected). Verified locally with `pytest tests/`.

Also corrected the coverage gate from `≥90%` to `≥89%` to match `fail_under = 89` in `pyproject.toml` (there's a TODO there about restoring 90% — until then the README should reflect reality).

Updated in both `README.md` and `README-ru.md`.

## Notes

I left the rest of the roadmap section as-is. The five WP components listed (Factual Memory, Experience Store, Identity Store, Reflection Engine, Session Manager) all check out as implemented under `src/atman/`. CLAUDE.md additionally mentions Affective Regulation, Web Dashboard, TUI, CLI as implemented and Skill Manager as not — but `src/atman/skills/` and the others do exist, so that's a separate doc-sync question rather than something to silently change here.

## Test plan

- [x] `pytest tests/` locally → `1764 passed, 138 skipped`
- [ ] CI passes on this branch


---
_Generated by [Claude Code](https://claude.ai/code/session_01BUckjsmLCaXBhq4yF6SYKG)_