### PR TITLE
Modify Sentry release tracking and checkout action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,14 +66,30 @@ jobs:
     name: Sentry release tracking
     runs-on: ubuntu-latest
     needs: check
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.SENTRY_AUTH_TOKEN != '' && secrets.SENTRY_ORG != '' && secrets.SENTRY_PROJECT != ''
+    
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      - name: Check Sentry config
+        id: sentry_check
+        run: |
+          if [ -z "${{ secrets.SENTRY_AUTH_TOKEN }}" ] || \
+             [ -z "${{ secrets.SENTRY_ORG }}" ] || \
+             [ -z "${{ secrets.SENTRY_PROJECT }}" ]; then
+            echo "Sentry is not configured, skipping"
+            echo "SENTRY_ENABLED=false" >> $GITHUB_ENV
+          else
+            echo "Sentry is configured"
+            echo "SENTRY_ENABLED=true" >> $GITHUB_ENV
+          fi
+
       - name: Create Sentry release
+        if: env.SENTRY_ENABLED == 'true'
         uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,16 +78,21 @@ jobs:
 
       - name: Check Sentry config
         id: sentry_check
+        env:
+          _SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          _SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          _SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         run: |
-          if [ -z "${{ secrets.SENTRY_AUTH_TOKEN }}" ] || \
-             [ -z "${{ secrets.SENTRY_ORG }}" ] || \
-             [ -z "${{ secrets.SENTRY_PROJECT }}" ]; then
+          if [ -z "$_SENTRY_AUTH_TOKEN" ] || \
+             [ -z "$_SENTRY_ORG" ] || \
+             [ -z "$_SENTRY_PROJECT" ]; then
             echo "Sentry is not configured, skipping"
             echo "SENTRY_ENABLED=false" >> $GITHUB_ENV
           else
             echo "Sentry is configured"
             echo "SENTRY_ENABLED=true" >> $GITHUB_ENV
           fi
+
 
       - name: Create Sentry release
         if: env.SENTRY_ENABLED == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,6 @@ jobs:
     name: Sentry release tracking
     runs-on: ubuntu-latest
     needs: check
-    
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
@@ -87,10 +86,10 @@ jobs:
              [ -z "$_SENTRY_ORG" ] || \
              [ -z "$_SENTRY_PROJECT" ]; then
             echo "Sentry is not configured, skipping"
-            echo "SENTRY_ENABLED=false" >> $GITHUB_ENV
+            echo "SENTRY_ENABLED=false" >> "$GITHUB_ENV"
           else
             echo "Sentry is configured"
-            echo "SENTRY_ENABLED=true" >> $GITHUB_ENV
+            echo "SENTRY_ENABLED=true" >> "$GITHUB_ENV"
           fi
 
 

--- a/spaces/linguistic-demo/lib/affect/emolex/emolex.py
+++ b/spaces/linguistic-demo/lib/affect/emolex/emolex.py
@@ -372,9 +372,7 @@ def emotion_score(text: str, lang: str = "ru", window: int = 3) -> dict:
             if consumed[j]:
                 continue
             prev = lemmas[j]
-            if prev in negs:
-                negated = not negated
-            elif (
+            if prev in negs or (
                 lang == "en"
                 and prev == "t"
                 and j - 1 >= max(0, i - window)

--- a/spaces/linguistic-demo/lib/affect/metrics.py
+++ b/spaces/linguistic-demo/lib/affect/metrics.py
@@ -143,6 +143,7 @@ def _count_negators(window: list[str], lang: str) -> int:
                 count += 1
     return count
 
+
 RU_POSITIVE_SINCERITY_MARKERS = frozenset(
     {
         "честно",

--- a/spaces/linguistic-demo/lib/affect/refusal_detector.py
+++ b/spaces/linguistic-demo/lib/affect/refusal_detector.py
@@ -165,7 +165,7 @@ _CONTRACTION_NEG_STEMS = frozenset(
         "mustn",
         "needn",
         "can",  # "can't" → ["can", "t"]; bare "can" never reaches this list because
-                # it never appears together with a trailing "t" outside contractions.
+        # it never appears together with a trailing "t" outside contractions.
     ]
 )
 
@@ -184,6 +184,7 @@ def _window_has_negation(lemmas: list[str], end: int, size: int) -> bool:
         if window[j + 1] == "t" and window[j] in _CONTRACTION_NEG_STEMS:
             return True
     return False
+
 
 # NRC threshold (density per 100 tokens) for "moral context"
 _MORAL_THRESHOLD_RU = 8.0

--- a/src/atman/adapters/memory/postgres_backend.py
+++ b/src/atman/adapters/memory/postgres_backend.py
@@ -421,7 +421,10 @@ class PostgresFactualMemory(FactualMemory):
 
         with db_span("postgresql", "query", collection="facts") as span:
             if span is not None:
-                span.set_data("db.query.mode", "vector" if (query and vec is not None) else "text" if query else "salience")
+                span.set_data(
+                    "db.query.mode",
+                    "vector" if (query and vec is not None) else "text" if query else "salience",
+                )
             with conn.cursor() as cur:
                 rows = self._load_rows(cur, where_sql, params, order_sql, limit)
             conn.commit()

--- a/src/atman/adapters/observability/sentry.py
+++ b/src/atman/adapters/observability/sentry.py
@@ -37,7 +37,7 @@ def init_sentry_from_env() -> bool:
     dsn = os.getenv("SENTRY_DSN", "").strip()
     if not dsn:
         return False
-    try:
+    with suppress(Exception):
         from atman.observability import init_observability
         from atman.observability import is_enabled as obs_enabled
 
@@ -46,8 +46,6 @@ def init_sentry_from_env() -> bool:
         global _initialized
         _initialized = obs_enabled()
         return _initialized
-    except Exception:
-        pass
     # Honour explicit opt-out even when the new module failed to import.
     if os.getenv("ATMAN_OBS_LEVEL", "").strip().lower() == "off":
         return False

--- a/src/atman/adapters/reflection/openai_reflection_model.py
+++ b/src/atman/adapters/reflection/openai_reflection_model.py
@@ -96,7 +96,9 @@ class OpenAIReflectionModel(ReflectionModel):
         for attempt in range(self._config.max_retries):
             attempts = attempt + 1
             try:
-                with ai_chat_span("openai-compat", self._config.model, op_name="reflection") as span:
+                with ai_chat_span(
+                    "openai-compat", self._config.model, op_name="reflection"
+                ) as span:
                     if span is not None:
                         span.set_data("reflection.output_model", output_model.__name__)
                         span.set_data("reflection.attempt", attempt + 1)

--- a/src/atman/affect/emolex/emolex.py
+++ b/src/atman/affect/emolex/emolex.py
@@ -372,9 +372,7 @@ def emotion_score(text: str, lang: str = "ru", window: int = 3) -> dict:
             if consumed[j]:
                 continue
             prev = lemmas[j]
-            if prev in negs:
-                negated = not negated
-            elif (
+            if prev in negs or (
                 lang == "en"
                 and prev == "t"
                 and j - 1 >= max(0, i - window)

--- a/src/atman/affect/metrics.py
+++ b/src/atman/affect/metrics.py
@@ -143,6 +143,7 @@ def _count_negators(window: list[str], lang: str) -> int:
                 count += 1
     return count
 
+
 RU_POSITIVE_SINCERITY_MARKERS = frozenset(
     {
         "честно",

--- a/src/atman/affect/refusal_detector.py
+++ b/src/atman/affect/refusal_detector.py
@@ -165,7 +165,7 @@ _CONTRACTION_NEG_STEMS = frozenset(
         "mustn",
         "needn",
         "can",  # "can't" → ["can", "t"]; bare "can" never reaches this list because
-                # it never appears together with a trailing "t" outside contractions.
+        # it never appears together with a trailing "t" outside contractions.
     ]
 )
 
@@ -184,6 +184,7 @@ def _window_has_negation(lemmas: list[str], end: int, size: int) -> bool:
         if window[j + 1] == "t" and window[j] in _CONTRACTION_NEG_STEMS:
             return True
     return False
+
 
 # NRC threshold (density per 100 tokens) for "moral context"
 _MORAL_THRESHOLD_RU = 8.0

--- a/src/atman/observability/spans.py
+++ b/src/atman/observability/spans.py
@@ -11,6 +11,7 @@ was not initialised (no DSN), the SDK returns a no-op span automatically.
 
 from __future__ import annotations
 
+import contextlib
 import os
 from collections.abc import Generator
 from contextlib import contextmanager
@@ -153,12 +154,10 @@ def job_scope(tags: dict[str, str]) -> Generator[None, None, None]:
         return
 
     scope_cm = None
-    try:
+    with contextlib.suppress(Exception):
         import sentry_sdk
 
         scope_cm = sentry_sdk.isolation_scope()
-    except Exception:
-        pass
 
     if scope_cm is None:
         yield

--- a/tests/observability/test_smoke.py
+++ b/tests/observability/test_smoke.py
@@ -77,9 +77,7 @@ class TestNewEntrypointAllLevels:
         mock_init.assert_called_once()
 
     @pytest.mark.parametrize("level", _NON_OFF)
-    def test_non_off_with_dsn_is_enabled(
-        self, level: str, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_non_off_with_dsn_is_enabled(self, level: str, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("SENTRY_DSN", _FAKE_DSN)
         with patch("sentry_sdk.init", MagicMock()):
             init_observability(level)


### PR DESCRIPTION
Updated Sentry release tracking conditions and checkout action version.

## PLAYBOOK markers

- [ ] I introduced new generalizable patterns and added PLAYBOOK markers
- [ ] I introduced no generalizable patterns (pure refactoring / project-specific changes)
- [ ] I'm uncertain — flagged in the PR description for author review

*See `AGENTS.md` § "PLAYBOOK markers" and `docs/development/PLAYBOOK_MARKERS.md` for criteria.*

---

## Что сделано

Кратко: смысл изменений для ревьюера.

## Как воспроизвести (демонстрация)

Заполните, если PR меняет поведение для пользователя, CLI или добавляет существенную фичу (см. *Definition of Demo* в `docs/development/DEVELOPMENT_STANDARD.md`). Иначе: **N/A** и одна фраза почему.

- **Команда(ы):** (например `make demo-experience`, `make demo-experience-fast` без пауз, `python3 src/demo.py`, `pytest tests/test_….py -q`)
- **Ожидаемый результат:** что должно появиться в выводе / в файлах (кратко)
- **Фикстуры / данные:** пути к `fixtures/` или шаги подготовки
- **Интерактивный CLI:** если демо только через REPL (`atman-experience`), укажите 2–5 строк для копипаста

## Тип изменений

- [ ] Исправление ошибки
- [ ] Новая возможность / документация
- [ ] Рефакторинг (без смены поведения)
- [ ] Прочее:

## Карта системы

См. [`docs/architecture/SYSTEM_MAP.md`](../docs/architecture/SYSTEM_MAP.md) и `DEVELOPMENT_STANDARD.md` §26.

- **Затронутые разделы карты:** (например, «§1.3 — добавлен `…Service`; §2.1 — связка с `…Store`; §3 — новый сценарий H»; иначе **N/A**)
- **Покрытие тестами:** какие тесты закрывают каждый затронутый пункт карты (`tests/test_…py::test_…`)
- **Закрытые GAP'ы из §4.5:** какие edge-case пропуски закрыты (если применимо)
- **Карта обновлена:** [ ] `docs/architecture/SYSTEM_MAP.md` + [ ] `SYSTEM_MAP-ru.md` (или **N/A** с причиной)

## Тесты-страховки агентной разработки

См. `DEVELOPMENT_STANDARD.md` §26.5. Отметьте те, что были обновлены, или
оставьте **N/A** с обоснованием:

- [ ] `tests/test_state_store_contract.py` — изменён порт `StateStore` или добавлен адаптер
- [ ] `tests/test_serialization_roundtrip.py` — изменены поля персистируемых моделей
- [ ] `tests/test_golden_schema.py` — изменена сериализация модели (с описанием миграции)
- [ ] `tests/test_cli_roundtrip.py` — изменён путь/формат файла стораджа
- [ ] `tests/test_cli_all_commands.py` — добавлена/изменена CLI-команда
- [ ] `tests/test_domain_invariants.py` — изменён или добавлен бизнес-инвариант
- [ ] `tests/test_e2e_full_cli.py` — изменён состав/порядок шагов lifecycle §3 A–G

## Чеклист

- [ ] Описание соответствует фактическим изменениям
- [ ] При необходимости обновлены `README` / `docs` / демо-сценарий (отметьте N/A если не нужно)
- [ ] При необходимости обновлены `docs/architecture/SYSTEM_MAP.md` и `SYSTEM_MAP-ru.md` (см. секцию выше; N/A если PR не меняет модули/порты/адаптеры/сервисы/точки входа/сценарии/edge-cases/регрессии)
- [ ] `ruff check src/ tests/` — 0 ошибок (N/A если PR не затрагивает код)
- [ ] `ruff format --check src/ tests/` — 0 ошибок (N/A если PR не затрагивает код)
- [ ] `pyright src/ tests/` — 0 ошибок (N/A если PR не затрагивает код)
- [ ] `bandit -c pyproject.toml -r src/atman/` — 0 ошибок (N/A если PR не затрагивает код)
- [ ] `pytest tests/ -v --cov=atman --cov-fail-under=90` — тесты проходят, покрытие ≥90% (N/A если PR не затрагивает код)
- [ ] GitHub Actions CI зелёный или локальные проверки выше объясняют, почему CI не применим

## Примечания

Риски, обратная совместимость, что проверить вручную — по необходимости.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hleserg/atman/pull/616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->