### PR TITLE
fix(observability): resolve Sentry unresolved issue noise

### DIFF
--- a/src/atman/core/ports/maintenance_queue.py
+++ b/src/atman/core/ports/maintenance_queue.py
@@ -15,6 +15,8 @@ def validate_enqueue_payload(job_name: JobName, payload: dict) -> None:
 
     Call this at the start of every ``MaintenanceQueue.enqueue()`` implementation
     so that structurally invalid jobs are rejected before they enter the queue.
+    Prevents ATMAN-BACKEND-C (``ValueError: key_moment_id missing``) from recurring
+    when moment-scoped jobs are enqueued without a payload key.
     """
     if job_name in _MOMENT_SCOPED_JOBS and not payload.get("key_moment_id"):
         if "key_moment_id" in payload:

--- a/src/atman/core/services/maintenance_worker.py
+++ b/src/atman/core/services/maintenance_worker.py
@@ -185,7 +185,7 @@ class MaintenanceWorker:
         ):
             self._queue.mark_skipped(job.id, reason="relation enrichment not configured")
             return _DispatchOutcome.SKIPPED, None
-        if not job.payload.get("key_moment_id"):
+        if not (job.payload or {}).get("key_moment_id"):
             self._queue.mark_skipped(job.id, reason="missing key_moment_id payload")
             return _DispatchOutcome.SKIPPED, None
         agent_id, moment_id = _require_moment_payload(job)
@@ -230,7 +230,7 @@ class MaintenanceWorker:
         if self._analyzer is None or self._state_store is None:
             self._queue.mark_skipped(job.id, reason="linguistic enrichment not configured")
             return _DispatchOutcome.SKIPPED, None
-        if not job.payload.get("key_moment_id"):
+        if not (job.payload or {}).get("key_moment_id"):
             self._queue.mark_skipped(job.id, reason="missing key_moment_id payload")
             return _DispatchOutcome.SKIPPED, None
         agent_id, moment_id = _require_moment_payload(job)

--- a/src/atman/core/services/maintenance_worker.py
+++ b/src/atman/core/services/maintenance_worker.py
@@ -185,6 +185,9 @@ class MaintenanceWorker:
         ):
             self._queue.mark_skipped(job.id, reason="relation enrichment not configured")
             return _DispatchOutcome.SKIPPED, None
+        if not job.payload.get("key_moment_id"):
+            self._queue.mark_skipped(job.id, reason="missing key_moment_id payload")
+            return _DispatchOutcome.SKIPPED, None
         agent_id, moment_id = _require_moment_payload(job)
         moment = self._state_store.get_key_moment(moment_id)
         if moment is None:
@@ -226,6 +229,9 @@ class MaintenanceWorker:
         """
         if self._analyzer is None or self._state_store is None:
             self._queue.mark_skipped(job.id, reason="linguistic enrichment not configured")
+            return _DispatchOutcome.SKIPPED, None
+        if not job.payload.get("key_moment_id"):
+            self._queue.mark_skipped(job.id, reason="missing key_moment_id payload")
             return _DispatchOutcome.SKIPPED, None
         agent_id, moment_id = _require_moment_payload(job)
         moment = self._state_store.get_key_moment(moment_id)

--- a/src/atman/core/services/maintenance_worker.py
+++ b/src/atman/core/services/maintenance_worker.py
@@ -323,14 +323,7 @@ class MaintenanceWorker:
                     "fact entity resolve failed for %r (fact %s)", ent.text, fact_id, exc_info=True
                 )
 
-        # Deduplicate (entity_id, role) — keep highest confidence
-        best_by_key: dict[tuple[UUID, str], FactEntityLink] = {}
-        for link in entity_links:
-            key = (link.entity_id, link.role)
-            prev = best_by_key.get(key)
-            if prev is None or link.confidence > prev.confidence:
-                best_by_key[key] = link
-        unique_links = list(best_by_key.values())
+        unique_links = _dedupe_fact_entity_links(entity_links)
 
         save_fn = getattr(self._factual_memory, "save_fact_entity_links", None)
         if save_fn is None:
@@ -366,6 +359,17 @@ class MaintenanceWorker:
             _LOG.warning("entity lookup failed for %r", entity.text, exc_info=True)
             return None
         return matches[0].id if matches else None
+
+
+def _dedupe_fact_entity_links(links: list[FactEntityLink]) -> list[FactEntityLink]:
+    """Keep one link per (entity_id, role) with the highest confidence."""
+    best_by_key: dict[tuple[UUID, str], FactEntityLink] = {}
+    for link in links:
+        key = (link.entity_id, link.role)
+        prev = best_by_key.get(key)
+        if prev is None or link.confidence > prev.confidence:
+            best_by_key[key] = link
+    return list(best_by_key.values())
 
 
 def _require_moment_payload(job: MaintenanceJob) -> tuple[UUID, UUID]:

--- a/src/atman/core/services/maintenance_worker.py
+++ b/src/atman/core/services/maintenance_worker.py
@@ -323,13 +323,13 @@ class MaintenanceWorker:
                 )
 
         # Deduplicate (entity_id, role) — keep highest confidence
-        seen_er: set[tuple[UUID, str]] = set()
-        unique_links: list[FactEntityLink] = []
+        best_by_key: dict[tuple[UUID, str], FactEntityLink] = {}
         for link in entity_links:
             key = (link.entity_id, link.role)
-            if key not in seen_er:
-                seen_er.add(key)
-                unique_links.append(link)
+            prev = best_by_key.get(key)
+            if prev is None or link.confidence > prev.confidence:
+                best_by_key[key] = link
+        unique_links = list(best_by_key.values())
 
         save_fn = getattr(self._factual_memory, "save_fact_entity_links", None)
         if save_fn is None:

--- a/src/atman/core/services/maintenance_worker.py
+++ b/src/atman/core/services/maintenance_worker.py
@@ -78,12 +78,13 @@ class MaintenanceWorker:
         import time as _time
 
         _t0 = _time.monotonic()
+        payload = job.payload or {}
         _slog(
             "job_start",
             job_id=str(job.id),
             job_name=job.job_name.value,
-            agent_id=str(job.payload.get("agent_id", "")),
-            payload_keys=list(job.payload.keys()),
+            agent_id=str(payload.get("agent_id", "")),
+            payload_keys=list(payload.keys()),
         )
         _tags: dict[str, str] = {
             "job.name": job.job_name.value,
@@ -145,7 +146,7 @@ class MaintenanceWorker:
         if job.agent_id is None:
             raise ValueError(f"salience_decay job {job.id} requires agent_id")
         agent_id = job.agent_id
-        cutoff_str = job.payload.get("cutoff")
+        cutoff_str = (job.payload or {}).get("cutoff")
         cutoff = datetime.fromisoformat(cutoff_str) if cutoff_str else datetime.now(UTC)
         count = self._decay.decay_pass(agent_id, cutoff=cutoff)
         return {"updated": count}
@@ -290,7 +291,7 @@ class MaintenanceWorker:
         if job.agent_id is None:
             raise ValueError(f"fact_entity_link job {job.id} requires agent_id")
         agent_id = job.agent_id
-        raw_fact_id = job.payload.get("fact_id")
+        raw_fact_id = (job.payload or {}).get("fact_id")
         if not raw_fact_id:
             raise ValueError(f"fact_entity_link job {job.id} missing fact_id payload")
         fact_id = UUID(str(raw_fact_id))
@@ -371,7 +372,7 @@ def _require_moment_payload(job: MaintenanceJob) -> tuple[UUID, UUID]:
     """Extract (agent_id, moment_id) from a moment-scoped enrichment job."""
     if job.agent_id is None:
         raise ValueError(f"{job.job_name.value} job {job.id} requires agent_id")
-    raw = job.payload.get("key_moment_id")
+    raw = (job.payload or {}).get("key_moment_id")
     if not raw:
         raise ValueError(f"{job.job_name.value} job {job.id} missing key_moment_id payload")
     return job.agent_id, UUID(str(raw))

--- a/src/atman/core/services/post_write_scheduler.py
+++ b/src/atman/core/services/post_write_scheduler.py
@@ -205,5 +205,5 @@ def _log_task_exception(task: asyncio.Task[None]) -> None:
         _LOG.warning(
             "post-write enrichment task failed: %s",
             exc,
-            exc_info=exc,
+            exc_info=True,
         )

--- a/src/atman/core/services/post_write_scheduler.py
+++ b/src/atman/core/services/post_write_scheduler.py
@@ -105,8 +105,11 @@ class PostWriteScheduler:
                     scheduled_at=when,
                 )
             except Exception:
-                _LOG.exception(
-                    "Failed to enqueue %s for moment %s — continuing", job_name.value, moment.id
+                _LOG.warning(
+                    "Failed to enqueue %s for moment %s — continuing",
+                    job_name.value,
+                    moment.id,
+                    exc_info=True,
                 )
 
     def schedule_for_fact(
@@ -127,7 +130,11 @@ class PostWriteScheduler:
                 scheduled_at=when,
             )
         except Exception:
-            _LOG.exception("Failed to enqueue fact_entity_link for fact %s — continuing", fact.id)
+            _LOG.warning(
+                "Failed to enqueue fact_entity_link for fact %s — continuing",
+                fact.id,
+                exc_info=True,
+            )
 
     # PLAYBOOK-START
     # id: fire-and-forget-asyncio-task-strong-refs
@@ -195,8 +202,8 @@ def _log_task_exception(task: asyncio.Task[None]) -> None:
         return
     exc = task.exception()
     if exc is not None:
-        _LOG.exception(
+        _LOG.warning(
             "post-write enrichment task failed: %s",
             exc,
-            exc_info=(type(exc), exc, exc.__traceback__),
+            exc_info=exc,
         )

--- a/src/atman/core/services/session_manager.py
+++ b/src/atman/core/services/session_manager.py
@@ -890,7 +890,12 @@ class SessionManager:
         try:
             self._post_write_scheduler.schedule_for_key_moment(moment, agent_id)
         except Exception:
-            _LOG.exception("post-write scheduler raised for moment %s — continuing", moment.id)
+            # WARNING + exc_info: degraded-mode path must not become a Sentry error event.
+            _LOG.warning(
+                "post-write scheduler raised for moment %s — continuing",
+                moment.id,
+                exc_info=True,
+            )
 
     def record_key_moment(self, session_id: UUID, moment: KeyMomentInput) -> None:
         """

--- a/src/atman/observability/scrubbing.py
+++ b/src/atman/observability/scrubbing.py
@@ -48,10 +48,88 @@ def make_event_scrubber(level: str) -> Any:
     return EventScrubber(denylist=denylist, recursive=True)
 
 
+_REFLECTION_OVERLOAD_LOGGER = "atman.reflection.overload"
+_TESTS_PATH_MARKERS: tuple[str, ...] = ("/tests/", "\\tests\\")
+_OPERATIONAL_ERROR_MESSAGE_MARKERS: tuple[str, ...] = (
+    "post-write scheduler raised",
+    "Failed to enqueue",
+)
+
+
+def _is_pytest_frame_path(path: str) -> bool:
+    if any(marker in path for marker in _TESTS_PATH_MARKERS):
+        return True
+    normalized = path.replace("\\", "/")
+    return "/tests/" in normalized or normalized.startswith("tests/")
+
+
+def _event_logger_name(event: dict[str, Any]) -> str:
+    return str(event.get("logger") or "")
+
+
+def _event_level(event: dict[str, Any]) -> str:
+    return str(event.get("level") or "").lower()
+
+
+def _event_message(event: dict[str, Any]) -> str:
+    logentry = event.get("logentry")
+    if isinstance(logentry, dict):
+        return str(logentry.get("formatted") or logentry.get("message") or "")
+    return str(event.get("message") or "")
+
+
+def _iter_stack_frame_paths(event: dict[str, Any], hint: dict[str, Any]) -> list[str]:
+    paths: list[str] = []
+    exception = event.get("exception")
+    if isinstance(exception, dict):
+        for exc_value in exception.get("values") or []:
+            if not isinstance(exc_value, dict):
+                continue
+            stacktrace = exc_value.get("stacktrace")
+            if not isinstance(stacktrace, dict):
+                continue
+            for frame in stacktrace.get("frames") or []:
+                if not isinstance(frame, dict):
+                    continue
+                for key in ("abs_path", "filename", "module"):
+                    value = frame.get(key)
+                    if value:
+                        paths.append(str(value))
+
+    exc_info = hint.get("exc_info")
+    if isinstance(exc_info, tuple) and len(exc_info) >= 3 and exc_info[2] is not None:
+        import traceback
+
+        for summary in traceback.extract_tb(exc_info[2]):
+            paths.append(summary.filename)
+    return paths
+
+
+def _stack_frame_in_tests(event: dict[str, Any], hint: dict[str, Any]) -> bool:
+    return any(_is_pytest_frame_path(path) for path in _iter_stack_frame_paths(event, hint))
+
+
+def _is_operational_error_log(event: dict[str, Any]) -> bool:
+    if _event_level(event) != "error":
+        return False
+    message = _event_message(event)
+    return any(marker in message for marker in _OPERATIONAL_ERROR_MESSAGE_MARKERS)
+
+
+def _should_drop_operational_signal(event: dict[str, Any], hint: dict[str, Any]) -> bool:
+    if _event_logger_name(event) == _REFLECTION_OVERLOAD_LOGGER:
+        return True
+    if _stack_frame_in_tests(event, hint):
+        return True
+    return _is_operational_error_log(event)
+
+
 def _make_before_send(level: str) -> Any:
-    """Factory for before_send callback (no-op filter for now; extensible)."""
+    """Factory for before_send callback — drop operational / test noise."""
 
     def before_send(event: dict[str, Any], hint: dict[str, Any]) -> dict[str, Any] | None:
+        if _should_drop_operational_signal(event, hint):
+            return None
         return event
 
     return before_send

--- a/src/atman/observability/scrubbing.py
+++ b/src/atman/observability/scrubbing.py
@@ -79,29 +79,36 @@ def _event_message(event: dict[str, Any]) -> str:
     return str(event.get("message") or "")
 
 
-def _iter_stack_frame_paths(event: dict[str, Any], hint: dict[str, Any]) -> list[str]:
+def _frame_paths_from_event(event: dict[str, Any]) -> list[str]:
     paths: list[str] = []
     exception = event.get("exception")
-    if isinstance(exception, dict):
-        for exc_value in exception.get("values") or []:
-            if not isinstance(exc_value, dict):
+    if not isinstance(exception, dict):
+        return paths
+    for exc_value in exception.get("values") or []:
+        if not isinstance(exc_value, dict):
+            continue
+        stacktrace = exc_value.get("stacktrace")
+        if not isinstance(stacktrace, dict):
+            continue
+        for frame in stacktrace.get("frames") or []:
+            if not isinstance(frame, dict):
                 continue
-            stacktrace = exc_value.get("stacktrace")
-            if not isinstance(stacktrace, dict):
-                continue
-            for frame in stacktrace.get("frames") or []:
-                if not isinstance(frame, dict):
-                    continue
-                for key in ("abs_path", "filename", "module"):
-                    value = frame.get(key)
-                    if value:
-                        paths.append(str(value))
-
-    exc_info = hint.get("exc_info")
-    if isinstance(exc_info, tuple) and len(exc_info) >= 3 and exc_info[2] is not None:
-        for summary in traceback.extract_tb(exc_info[2]):
-            paths.append(summary.filename)
+            for key in ("abs_path", "filename", "module"):
+                value = frame.get(key)
+                if value:
+                    paths.append(str(value))
     return paths
+
+
+def _frame_paths_from_hint(hint: dict[str, Any]) -> list[str]:
+    exc_info = hint.get("exc_info")
+    if not isinstance(exc_info, tuple) or len(exc_info) < 3 or exc_info[2] is None:
+        return []
+    return [summary.filename for summary in traceback.extract_tb(exc_info[2])]
+
+
+def _iter_stack_frame_paths(event: dict[str, Any], hint: dict[str, Any]) -> list[str]:
+    return _frame_paths_from_event(event) + _frame_paths_from_hint(hint)
 
 
 def _stack_frame_in_tests(event: dict[str, Any], hint: dict[str, Any]) -> bool:

--- a/src/atman/observability/scrubbing.py
+++ b/src/atman/observability/scrubbing.py
@@ -6,6 +6,7 @@ never reach Sentry SaaS: memory contents, reflections, embeddings, prompts.
 
 from __future__ import annotations
 
+import traceback
 from typing import Any
 
 ATMAN_EXTRA_KEYS: list[str] = [
@@ -98,8 +99,6 @@ def _iter_stack_frame_paths(event: dict[str, Any], hint: dict[str, Any]) -> list
 
     exc_info = hint.get("exc_info")
     if isinstance(exc_info, tuple) and len(exc_info) >= 3 and exc_info[2] is not None:
-        import traceback
-
         for summary in traceback.extract_tb(exc_info[2]):
             paths.append(summary.filename)
     return paths
@@ -110,7 +109,7 @@ def _stack_frame_in_tests(event: dict[str, Any], hint: dict[str, Any]) -> bool:
 
 
 def _is_operational_error_log(event: dict[str, Any]) -> bool:
-    if _event_level(event) != "error":
+    if _event_level(event) not in ("error", "fatal"):
         return False
     message = _event_message(event)
     return any(marker in message for marker in _OPERATIONAL_ERROR_MESSAGE_MARKERS)

--- a/tests/observability/test_scrubbing.py
+++ b/tests/observability/test_scrubbing.py
@@ -41,6 +41,30 @@ def test_before_send_passes_event():
     assert result is event
 
 
+def test_before_send_drops_reflection_overload_logger():
+    fn = _make_before_send("minimal")
+    event = {"logger": "atman.reflection.overload", "message": "reflection overload: too deep"}
+    assert fn(event, {}) is None
+
+
+def test_before_send_drops_pytest_stack_frames():
+    fn = _make_before_send("minimal")
+    event = {
+        "exception": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [
+                            {"filename": "tests/test_post_write_wiring.py", "lineno": 108},
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+    assert fn(event, {}) is None
+
+
 def test_before_send_transaction_drops_health():
     fn = _make_before_send_transaction("minimal")
     for route in _HEALTH_ROUTES:

--- a/tests/observability/test_scrubbing_before_send.py
+++ b/tests/observability/test_scrubbing_before_send.py
@@ -1,0 +1,146 @@
+"""Unit tests for before_send operational-signal filtering."""
+
+from __future__ import annotations
+
+import sys
+
+from atman.observability.scrubbing import (
+    _REFLECTION_OVERLOAD_LOGGER,
+    _make_before_send,
+    _should_drop_operational_signal,
+)
+
+
+def _before_send(level: str = "minimal"):
+    return _make_before_send(level)
+
+
+def test_before_send_drops_reflection_overload_logger():
+    event = {
+        "logger": _REFLECTION_OVERLOAD_LOGGER,
+        "level": "critical",
+        "logentry": {"formatted": "reflection overload: daily cap exceeded"},
+    }
+    assert _before_send()(event, {}) is None
+
+
+def test_before_send_drops_tests_stack_frame_unix():
+    event = {
+        "level": "error",
+        "exception": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [
+                            {"abs_path": "/repo/src/atman/foo.py", "filename": "foo.py"},
+                            {"abs_path": "/repo/tests/test_foo.py", "filename": "test_foo.py"},
+                        ]
+                    }
+                }
+            ]
+        },
+    }
+    assert _before_send()(event, {}) is None
+
+
+def test_before_send_drops_tests_stack_frame_windows():
+    event = {
+        "level": "error",
+        "exception": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "abs_path": r"C:\projects\atman\tests\test_bar.py",
+                                "filename": "test_bar.py",
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+    }
+    assert _before_send()(event, {}) is None
+
+
+def test_before_send_drops_tests_stack_from_hint_exc_info():
+    try:
+        raise RuntimeError("pytest noise")
+    except RuntimeError:
+        exc_info = sys.exc_info()
+    event: dict = {"level": "error"}
+    assert _before_send()(event, {"exc_info": exc_info}) is None
+
+
+def test_before_send_drops_post_write_scheduler_error_message():
+    event = {
+        "level": "error",
+        "logentry": {
+            "formatted": "post-write scheduler raised for moment abc — continuing",
+        },
+    }
+    assert _before_send()(event, {}) is None
+
+
+def test_before_send_drops_failed_to_enqueue_error_message():
+    event = {
+        "level": "error",
+        "logentry": {
+            "formatted": "Failed to enqueue fact_entity_link for fact xyz — continuing",
+        },
+    }
+    assert _before_send()(event, {}) is None
+
+
+def test_before_send_keeps_operational_markers_at_warning():
+    event = {
+        "level": "warning",
+        "logentry": {"formatted": "post-write scheduler raised for moment abc — continuing"},
+    }
+    result = _before_send()(event, {})
+    assert result is event
+
+
+def test_before_send_keeps_unrelated_error():
+    event = {
+        "level": "error",
+        "logger": "atman.core.services.session_manager",
+        "logentry": {"formatted": "unexpected persistence failure"},
+        "exception": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [
+                            {"abs_path": "/repo/src/atman/core/services/session_manager.py"},
+                        ]
+                    }
+                }
+            ]
+        },
+    }
+    result = _before_send()(event, {})
+    assert result is event
+
+
+def test_should_drop_operational_signal_direct():
+    assert _should_drop_operational_signal({"logger": _REFLECTION_OVERLOAD_LOGGER}, {}) is True
+    assert (
+        _should_drop_operational_signal(
+            {
+                "level": "error",
+                "exception": {
+                    "values": [{"stacktrace": {"frames": [{"filename": "tests/test_x.py"}]}}]
+                },
+            },
+            {},
+        )
+        is True
+    )
+    assert (
+        _should_drop_operational_signal(
+            {"level": "warning", "logentry": {"formatted": "Failed to enqueue x"}},
+            {},
+        )
+        is False
+    )

--- a/tests/observability/test_scrubbing_before_send.py
+++ b/tests/observability/test_scrubbing_before_send.py
@@ -126,6 +126,21 @@ def test_before_send_keeps_unrelated_error():
     assert result is event
 
 
+def test_before_send_tolerates_malformed_exception_structure():
+    event = {
+        "level": "error",
+        "exception": {
+            "values": [
+                "not-a-dict",
+                {"stacktrace": "not-a-dict"},
+                {"stacktrace": {"frames": ["not-a-frame", {}]}},
+            ]
+        },
+    }
+    result = _before_send()(event, {})
+    assert result is event
+
+
 def test_should_drop_operational_signal_direct():
     assert _should_drop_operational_signal({"logger": _REFLECTION_OVERLOAD_LOGGER}, {}) is True
     assert (

--- a/tests/observability/test_scrubbing_before_send.py
+++ b/tests/observability/test_scrubbing_before_send.py
@@ -65,12 +65,14 @@ def test_before_send_drops_tests_stack_frame_windows():
 
 
 def test_before_send_drops_tests_stack_from_hint_exc_info():
+    captured_exc: tuple[type[BaseException], BaseException, object] | None = None
     try:
         raise RuntimeError("pytest noise")
     except RuntimeError:
-        exc_info = sys.exc_info()
+        captured_exc = sys.exc_info()
+    assert captured_exc is not None
     event: dict = {"level": "error"}
-    assert _before_send()(event, {"exc_info": exc_info}) is None
+    assert _before_send()(event, {"exc_info": captured_exc}) is None
 
 
 def test_before_send_drops_post_write_scheduler_error_message():

--- a/tests/observability/test_scrubbing_before_send.py
+++ b/tests/observability/test_scrubbing_before_send.py
@@ -65,12 +65,13 @@ def test_before_send_drops_tests_stack_frame_windows():
 
 
 def test_before_send_drops_tests_stack_from_hint_exc_info():
-    captured_exc: tuple[type[BaseException], BaseException, object] | None = None
+    captured_exc = None
     try:
         raise RuntimeError("pytest noise")
     except RuntimeError:
         captured_exc = sys.exc_info()
     assert captured_exc is not None
+    assert captured_exc[0] is RuntimeError
     event: dict = {"level": "error"}
     assert _before_send()(event, {"exc_info": captured_exc}) is None
 

--- a/tests/test_new_v3_services.py
+++ b/tests/test_new_v3_services.py
@@ -460,6 +460,73 @@ class TestMaintenanceWorker:
         assert the_job.status is JobStatus.skipped
         assert "key_moment_id" in (the_job.error or "")
 
+    def test_lingvo_null_payload_skipped(self) -> None:
+        from atman.core.models.maintenance import MaintenanceJob
+
+        q = InMemoryMaintenanceQueue()
+        worker = MaintenanceWorker(
+            q,
+            state_store=InMemoryStateStore(),
+            linguistic_analyzer=MagicMock(),
+        )
+        job = MaintenanceJob.model_construct(
+            job_name=JobName.lingvo_enrich,
+            agent_id=uuid4(),
+            payload=None,
+        )
+        q._jobs.append(job)
+        worker.run_once()
+        the_job = next(j for j in q.list_jobs() if j.id == job.id)
+        assert the_job.status is JobStatus.skipped
+
+    def test_fact_entity_link_dedup_keeps_highest_confidence(self) -> None:
+        from atman.core.models.entity import EntityType
+        from atman.core.models.fact import FactRecord
+        from atman.core.models.maintenance import MaintenanceJob
+        from atman.core.ports.linguistic import DetectedEntity, UserMessageAnalysis
+
+        agent_id = uuid4()
+        fact_id = uuid4()
+        entity_id = uuid4()
+        fact = FactRecord(id=fact_id, agent_id=agent_id, content="Alice met Bob", source="test")
+
+        ent = DetectedEntity(text="Alice", entity_type=EntityType.person, confidence=0.4)
+        ent_dup = DetectedEntity(text="Alice", entity_type=EntityType.person, confidence=0.9)
+        analysis = UserMessageAnalysis(text=fact.content or "", entities=[ent, ent_dup])
+
+        factual = MagicMock()
+        factual.get_fact.return_value = fact
+        saved: list = []
+
+        def _save(_fact_id: UUID, _agent_id: UUID, links: list) -> None:
+            saved.extend(links)
+
+        factual.save_fact_entity_links = _save
+
+        registry = MagicMock()
+        registry.resolve_or_create.return_value = (MagicMock(id=entity_id), True)
+
+        analyzer = MagicMock()
+        analyzer.analyze_user_message.return_value = analysis
+
+        q = InMemoryMaintenanceQueue()
+        worker = MaintenanceWorker(
+            q,
+            factual_memory=factual,
+            linguistic_analyzer=analyzer,
+            entity_registry=registry,
+        )
+        job = MaintenanceJob(
+            job_name=JobName.fact_entity_link,
+            agent_id=agent_id,
+            payload={"fact_id": str(fact_id)},
+        )
+        q._jobs.append(job)
+        worker.run_once()
+
+        assert len(saved) == 1
+        assert saved[0].confidence == 0.9
+
 
 def test_decay_pass_high_importance_decays_slower_than_low() -> None:
     """High-importance (>0.8) moments must decay 30% slower per the contract

--- a/tests/test_new_v3_services.py
+++ b/tests/test_new_v3_services.py
@@ -525,7 +525,7 @@ class TestMaintenanceWorker:
         worker.run_once()
 
         assert len(saved) == 1
-        assert saved[0].confidence == 0.9
+        assert saved[0].confidence == pytest.approx(0.9)
 
 
 def test_decay_pass_high_importance_decays_slower_than_low() -> None:

--- a/tests/test_new_v3_services.py
+++ b/tests/test_new_v3_services.py
@@ -498,7 +498,7 @@ class TestMaintenanceWorker:
         factual.get_fact.return_value = fact
         saved: list = []
 
-        def _save(_fact_id: UUID, _agent_id: UUID, links: list) -> None:
+        def _save(_fact_id, _agent_id, links: list) -> None:
             saved.extend(links)
 
         factual.save_fact_entity_links = _save

--- a/tests/test_new_v3_services.py
+++ b/tests/test_new_v3_services.py
@@ -440,6 +440,26 @@ class TestMaintenanceWorker:
         worker.run_once()
         assert q.list_jobs()[0].status is JobStatus.failed
 
+    def test_mrebel_missing_key_moment_id_legacy_job_skipped(self) -> None:
+        """Pre-#617 queue rows skip cleanly instead of failing into Sentry."""
+        from atman.core.models.maintenance import MaintenanceJob
+
+        q = InMemoryMaintenanceQueue()
+        store = InMemoryStateStore()
+        worker = MaintenanceWorker(
+            q,
+            state_store=store,
+            entity_relation_extractor=MagicMock(extract_relations=lambda text, entities: []),
+            entity_relation_store=MagicMock(),
+            entity_registry=MagicMock(),
+        )
+        job = MaintenanceJob(job_name=JobName.mrebel_extract, agent_id=uuid4(), payload={})
+        q._jobs.append(job)
+        worker.run_once()
+        the_job = next(j for j in q.list_jobs() if j.id == job.id)
+        assert the_job.status is JobStatus.skipped
+        assert "key_moment_id" in (the_job.error or "")
+
 
 def test_decay_pass_high_importance_decays_slower_than_low() -> None:
     """High-importance (>0.8) moments must decay 30% slower per the contract

--- a/tests/test_post_write_scheduler.py
+++ b/tests/test_post_write_scheduler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
@@ -75,7 +76,9 @@ def test_schedule_for_key_moment_swallows_queue_errors(caplog) -> None:
     agent = uuid4()
     moment = _moment()
     # Must not propagate the exception — post-write hooks are best-effort.
-    scheduler.schedule_for_key_moment(moment, agent)
+    with caplog.at_level(logging.WARNING):
+        scheduler.schedule_for_key_moment(moment, agent)
+    assert any(r.levelno == logging.WARNING and "continuing" in r.message for r in caplog.records)
 
 
 def test_schedule_at_specific_time() -> None:

--- a/tests/test_post_write_wiring.py
+++ b/tests/test_post_write_wiring.py
@@ -3,6 +3,7 @@ and MaintenanceWorker dispatch for ``mrebel_extract`` / ``lingvo_enrich``."""
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 from uuid import UUID, uuid4
@@ -100,7 +101,7 @@ def test_session_manager_schedules_on_finish_after_persist(tmp_path) -> None:
     assert store.get_key_moment(moment.id) is not None
 
 
-def test_session_manager_swallow_scheduler_errors(tmp_path) -> None:
+def test_session_manager_swallow_scheduler_errors(tmp_path, caplog) -> None:
     """A broken scheduler must not bring the finish path down."""
 
     class _Boom:
@@ -118,8 +119,12 @@ def test_session_manager_swallow_scheduler_errors(tmp_path) -> None:
     mgr.append_key_moment(ctx.session_id, _moment())
     # finish_session must complete despite the scheduler raising for every
     # moment — the exception is swallowed inside _schedule_post_write.
-    _finish(mgr, ctx.session_id)
+    with caplog.at_level(logging.WARNING):
+        _finish(mgr, ctx.session_id)
     assert mgr.get_active_session(ctx.session_id) is None
+    assert any(
+        r.levelno == logging.WARNING and "continuing" in r.message for r in caplog.records
+    )
 
 
 def test_session_manager_no_scheduler_is_noop(tmp_path) -> None:

--- a/tests/test_post_write_wiring.py
+++ b/tests/test_post_write_wiring.py
@@ -122,9 +122,7 @@ def test_session_manager_swallow_scheduler_errors(tmp_path, caplog) -> None:
     with caplog.at_level(logging.WARNING):
         _finish(mgr, ctx.session_id)
     assert mgr.get_active_session(ctx.session_id) is None
-    assert any(
-        r.levelno == logging.WARNING and "continuing" in r.message for r in caplog.records
-    )
+    assert any(r.levelno == logging.WARNING and "continuing" in r.message for r in caplog.records)
 
 
 def test_session_manager_no_scheduler_is_noop(tmp_path) -> None:


### PR DESCRIPTION
## Summary

Addresses 8 unresolved Sentry issues in org `atman-o6` (mostly false-positive ERROR events from intentional degraded-mode paths and pytest runs with `SENTRY_DSN`).

- Swallowed post-write scheduler failures now log at **WARNING** with `exc_info` (`session_manager`, `post_write_scheduler`) so Sentry LoggingIntegration does not file issues.
- `before_send` drops operational signals: `atman.reflection.overload` logger, pytest stack frames, and legacy ERROR logs for known swallowed enqueue messages.
- `MaintenanceWorker` skips moment-scoped jobs missing `key_moment_id` instead of raising (belt-and-suspenders after enqueue validation / ATMAN-BACKEND-C).
- Tests: `test_scrubbing_before_send.py`, updates to post-write and v3 service tests.

## Sentry issues targeted

| Issue area | Fix |
|------------|-----|
| ATMAN-BACKEND-B (`queue offline`) | WARNING + test-frame filter |
| ATMAN-BACKEND-C (`key_moment_id`) | Already fixed at enqueue; worker skip + doc |
| maintenance_worker / post_write_scheduler RuntimeError | WARNING + filters |
| reflection overload | `before_send` drop |
| Тестовый алерт | test-frame filter |

## Test plan

- [x] `pytest tests/observability/test_scrubbing*.py`
- [x] ruff + pyright on touched modules
- [ ] CI green
- [ ] Resolve/verify issues in Sentry after deploy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hleserg/atman/pull/620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->