### PR TITLE
docs(readme): honest roadmap readiness levels

### DIFF
--- a/README-ru.md
+++ b/README-ru.md
@@ -62,20 +62,27 @@ Atman - это инфраструктура с открытым исходным
 ● Исследование          ✅ Завершено
 ● Проектирование        ✅ Завершено
 ● Прототипирование      ← Мы здесь
-  ├─ Factual Memory     ✅ Реализовано (v0.1.0)
-  ├─ Experience Store   ✅ Реализовано (WP02)
-  ├─ Identity Store     ✅ Реализовано (WP03)
-  ├─ Reflection Engine  ✅ Реализовано (WP04)
-  ├─ Session Manager    ✅ Реализовано (WP05)
+  ├─ Factual Memory     ✅ Стабильно (v0.1.0)
+  ├─ Experience Store   ✅ Стабильно (WP02)
+  ├─ Session Manager    🔧 Высокая готовность — отладка (текущий фокус)
+  ├─ Reflection Engine  🔧 Средняя готовность — в разработке
+  ├─ Skill Manager      🔧 Средняя готовность — в разработке
+  ├─ Identity Store     🔧 Низкая готовность — в разработке
   └─ CI и покрытие тестами ✅ GitHub Actions для `main`/PR (`make check`, pytest-cov ≥90%)
-○ Первая реализация
+○ Первый продакшен-срез
 ○ Интеграция
 ○ Развитие
 ```
 
-### Готовые компоненты
+**Честный срез (май 2026):** основы памяти (факты + опыт от первого лица) можно использовать отдельно. У **сессии**, **рефлексии**, **идентичности** и **навыков** уже есть прототипы, демо и тесты — но полный цикл «непрерывной личности» **ещё не готов к продакшену**. Сейчас команда на **Session Manager**: интеграция и отладка перед более широким онбордингом.
+
+Легенда готовности: **высокая** = основной путь есть, идёт доводка · **средняя** = зрелый прототип, пробелы в интеграции · **низкая** = ранний срез, пока не тянет продуктовую историю.
+
+### Статус компонентов
 
 - 🌐 **Сайт — демо в терминале:** [atmanai.dev/demo.html](https://atmanai.dev/demo.html) (переключатель RU/EN, как на главной)
+
+#### Стабильный фундамент
 
 **✅ Factual Memory Adapter** ([PR #73](https://github.com/hleserg/atman/pull/73))
 Минимальный слой для хранения проверяемых фактов без интерпретаций.
@@ -95,23 +102,30 @@ Atman - это инфраструктура с открытым исходным
 - 📚 [Руководство (RU)](docs/features/experience-store/README-ru.md) · [EN](docs/features/experience-store/README.md)
 - ▶️ Демо: `make demo-experience` или `python3 src/demo_experience_store.py` (мгновенно: `make demo-experience-fast`)
 
-**✅ Identity Store** (рабочий пакет 03)
-Честный bootstrap идентичности, eigenstate, трёхслойный self-narrative, снимки, CLI.
+#### В активной разработке
 
-- 📚 [Руководство (RU)](docs/features/identity-store/README-ru.md) · [EN](docs/features/identity-store/README.md)
-- ▶️ Демо: `make demo-identity` или `python3 src/demo_identity.py` (мгновенно: `make demo-identity-fast`)
+**🔧 Session Manager** (рабочий пакет 05) — **высокая готовность · текущий фокус**
+Сессионный runtime в реальном времени: окраска опыта от первого лица, key moments с обязательной эмоциональной меткой, генерация eigenstate, обновление нарратива. Прототип на месте; сейчас — проводка, краевые случаи и отладка перед более широкой аудиторией.
 
-**✅ Reflection Engine** (рабочий пакет 04)
-Micro / daily / deep рефлексия, паттерны, хуки правки нарратива, оценка здоровья по Джаходе, советник по принципам.
+- 📚 [Руководство (RU)](docs/features/session-manager/README-ru.md) · [EN](docs/features/session-manager/README.md)
+- ▶️ Демо: `make demo-session` или `python3 src/demo_session_manager.py` (мгновенно: `make demo-session-fast`)
+
+**🔧 Reflection Engine** (рабочий пакет 04) — **средняя готовность**
+Micro / daily / deep рефлексия, паттерны, хуки правки нарратива, оценка здоровья по Джаходе, советник по принципам. Демо и тесты есть; «внутренняя жизнь» между сессиями для продакшен-агентов пока не опирается на это надёжно.
 
 - 📚 [Руководство (RU)](docs/features/reflection-engine/README-ru.md) · [EN](docs/features/reflection-engine/README.md)
 - ▶️ Демо: `make demo-reflection` или `python3 src/demo_reflection.py` (мгновенно: `make demo-reflection-fast`)
 
-**✅ Session Manager** (рабочий пакет 05)
-Сессионный runtime в реальном времени: окраска опыта от первого лица, key moments с обязательной эмоциональной меткой, генерация eigenstate, обновление нарратива.
+**🔧 Skill Manager** (рабочий пакет 08) — **средняя готовность**
+Слой переносимых навыков (дизайн + бэклог; реализация в процессе). Форма API и хранения может меняться по мере стабилизации сессии и рефлексии.
 
-- 📚 [Руководство (RU)](docs/features/session-manager/README-ru.md) · [EN](docs/features/session-manager/README.md)
-- ▶️ Демо: `make demo-session` или `python3 src/demo_session_manager.py` (мгновенно: `make demo-session-fast`)
+- 📚 Заметки по дизайну: [`docs/archive/2026-05/skill-manager-design.md`](docs/archive/2026-05/skill-manager-design.md)
+
+**🔧 Identity Store** (рабочий пакет 03) — **низкая готовность**
+Честный bootstrap идентичности, eigenstate, трёхслойный self-narrative, снимки, CLI. Полезно для экспериментов; относительно сессионного пути, который сейчас укрепляем, — ещё рано.
+
+- 📚 [Руководство (RU)](docs/features/identity-store/README-ru.md) · [EN](docs/features/identity-store/README.md)
+- ▶️ Демо: `make demo-identity` или `python3 src/demo_identity.py` (мгновенно: `make demo-identity-fast`)
 
 ```bash
 # Быстрый старт (установка + интерактивный CLI фактов)

--- a/README.md
+++ b/README.md
@@ -60,20 +60,27 @@ Under the hood — seven components: store of lived experiences, reflection engi
 ● Research              ✅ Complete
 ● Design                ✅ Complete
 ● Prototyping           ← We are here
-  ├─ Factual Memory     ✅ Implemented (v0.1.0)
-  ├─ Experience Store   ✅ Implemented (WP02)
-  ├─ Identity Store     ✅ Implemented (WP03)
-  ├─ Reflection Engine  ✅ Implemented (WP04)
-  ├─ Session Manager    ✅ Implemented (WP05)
+  ├─ Factual Memory     ✅ Stable (v0.1.0)
+  ├─ Experience Store   ✅ Stable (WP02)
+  ├─ Session Manager    🔧 High readiness — debugging (current focus)
+  ├─ Reflection Engine  🔧 Medium readiness — in development
+  ├─ Skill Manager      🔧 Medium readiness — in development
+  ├─ Identity Store     🔧 Low readiness — in development
   └─ CI & test coverage ✅ GitHub Actions on `main`/PRs (`make check`, pytest-cov ≥90%)
-○ First implementation
+○ First production slice
 ○ Integration
 ○ Evolution
 ```
 
-### Ready components
+**Honest snapshot (May 2026):** memory foundations (facts + first-hand experience) are usable on their own. **Session**, **reflection**, **identity**, and **skills** already have prototype code, demos, and tests — but the full “continuous identity” loop is **not production-ready** yet. Right now the team is on **Session Manager**: integration and debugging before wider onboarding.
+
+Readiness legend: **high** = core path exists, hardening in progress · **medium** = substantial prototype, gaps in integration · **low** = early slice, needs more work before it carries the product story.
+
+### Component status
 
 - 🌐 **Site — terminal demos:** [atmanai.dev/demo.html](https://atmanai.dev/demo.html) (RU/EN toggle matches the main landing)
+
+#### Stable foundations
 
 **✅ Factual Memory Adapter** ([PR #73](https://github.com/hleserg/atman/pull/73))
 Minimal layer for storing verifiable facts without interpretations.
@@ -93,23 +100,30 @@ First-hand lived experience: `SessionExperience`, `KeyMoment`, salience decay, r
 - 📚 [Guide (EN)](docs/features/experience-store/README.md) · [RU](docs/features/experience-store/README-ru.md)
 - ▶️ Demo: `make demo-experience` or `python3 src/demo_experience_store.py` (`make demo-experience-fast` for instant output)
 
-**✅ Identity Store** (work package 03)
-Honest bootstrap identity, eigenstate, three-layer self-narrative, snapshots, CLI.
+#### In active development
 
-- 📚 [Guide (EN)](docs/features/identity-store/README.md) · [RU](docs/features/identity-store/README-ru.md)
-- ▶️ Demo: `make demo-identity` or `python3 src/demo_identity.py` (`make demo-identity-fast` for instant output)
+**🔧 Session Manager** (work package 05) — **high readiness · current focus**
+Real-time session runtime: first-hand experience coloring, key moments with mandatory emotional marking, eigenstate generation, narrative updates. Prototype is in place; active work is wiring, edge cases, and debugging before a broader audience.
 
-**✅ Reflection Engine** (work package 04)
-Micro / daily / deep reflection, patterns, narrative revision hooks, Jahoda health assessment, principle advisor.
+- 📚 [Guide (EN)](docs/features/session-manager/README.md) · [RU](docs/features/session-manager/README-ru.md)
+- ▶️ Demo: `make demo-session` or `python3 src/demo_session_manager.py` (`make demo-session-fast` for instant output)
+
+**🔧 Reflection Engine** (work package 04) — **medium readiness**
+Micro / daily / deep reflection, patterns, narrative revision hooks, Jahoda health assessment, principle advisor. Runnable demos and tests; not yet a dependable between-session “inner life” for production agents.
 
 - 📚 [Guide (EN)](docs/features/reflection-engine/README.md) · [RU](docs/features/reflection-engine/README-ru.md)
 - ▶️ Demo: `make demo-reflection` or `python3 src/demo_reflection.py` (`make demo-reflection-fast` for instant output)
 
-**✅ Session Manager** (work package 05)
-Real-time session runtime: first-hand experience coloring, key moments with mandatory emotional marking, eigenstate generation, narrative updates.
+**🔧 Skill Manager** (work package 08) — **medium readiness**
+Transferable skills layer (design + backlog; implementation in progress). Expect API and storage shape to move as session and reflection paths stabilize.
 
-- 📚 [Guide (EN)](docs/features/session-manager/README.md) · [RU](docs/features/session-manager/README-ru.md)
-- ▶️ Demo: `make demo-session` or `python3 src/demo_session_manager.py` (`make demo-session-fast` for instant output)
+- 📚 Design notes: [`docs/archive/2026-05/skill-manager-design.md`](docs/archive/2026-05/skill-manager-design.md)
+
+**🔧 Identity Store** (work package 03) — **low readiness**
+Honest bootstrap identity, eigenstate, three-layer self-narrative, snapshots, CLI. Useful for experiments; still early relative to the session-centric path we are hardening now.
+
+- 📚 [Guide (EN)](docs/features/identity-store/README.md) · [RU](docs/features/identity-store/README-ru.md)
+- ▶️ Demo: `make demo-identity` or `python3 src/demo_identity.py` (`make demo-identity-fast` for instant output)
 
 ```bash
 # Quick start (install + interactive factual CLI)

--- a/docs/content/README-ru.md
+++ b/docs/content/README-ru.md
@@ -5,6 +5,8 @@
 > **Непрерывная личность для ваших агентов**
 
 [![CI](https://github.com/hleserg/atman/actions/workflows/ci.yml/badge.svg)](https://github.com/hleserg/atman/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/github/hleserg/atman/graph/badge.svg?token=1S9D9U8QZP)](https://codecov.io/github/hleserg/atman)
+[![CodeFactor](https://www.codefactor.io/repository/github/hleserg/atman/badge)](https://www.codefactor.io/repository/github/hleserg/atman)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
@@ -60,20 +62,27 @@ Atman - это инфраструктура с открытым исходным
 ● Исследование          ✅ Завершено
 ● Проектирование        ✅ Завершено
 ● Прототипирование      ← Мы здесь
-  ├─ Factual Memory     ✅ Реализовано (v0.1.0)
-  ├─ Experience Store   ✅ Реализовано (WP02)
-  ├─ Identity Store     ✅ Реализовано (WP03)
-  ├─ Reflection Engine  ✅ Реализовано (WP04)
-  ├─ Session Manager    ✅ Реализовано (WP05)
+  ├─ Factual Memory     ✅ Стабильно (v0.1.0)
+  ├─ Experience Store   ✅ Стабильно (WP02)
+  ├─ Session Manager    🔧 Высокая готовность — отладка (текущий фокус)
+  ├─ Reflection Engine  🔧 Средняя готовность — в разработке
+  ├─ Skill Manager      🔧 Средняя готовность — в разработке
+  ├─ Identity Store     🔧 Низкая готовность — в разработке
   └─ CI и покрытие тестами ✅ GitHub Actions для `main`/PR (`make check`, pytest-cov ≥90%)
-○ Первая реализация
+○ Первый продакшен-срез
 ○ Интеграция
 ○ Развитие
 ```
 
-### Готовые компоненты
+**Честный срез (май 2026):** основы памяти (факты + опыт от первого лица) можно использовать отдельно. У **сессии**, **рефлексии**, **идентичности** и **навыков** уже есть прототипы, демо и тесты — но полный цикл «непрерывной личности» **ещё не готов к продакшену**. Сейчас команда на **Session Manager**: интеграция и отладка перед более широким онбордингом.
+
+Легенда готовности: **высокая** = основной путь есть, идёт доводка · **средняя** = зрелый прототип, пробелы в интеграции · **низкая** = ранний срез, пока не тянет продуктовую историю.
+
+### Статус компонентов
 
 - 🌐 **Сайт — демо в терминале:** [atmanai.dev/demo.html](https://atmanai.dev/demo.html) (переключатель RU/EN, как на главной)
+
+#### Стабильный фундамент
 
 **✅ Factual Memory Adapter** ([PR #73](https://github.com/hleserg/atman/pull/73))
 Минимальный слой для хранения проверяемых фактов без интерпретаций.
@@ -93,23 +102,30 @@ Atman - это инфраструктура с открытым исходным
 - 📚 [Руководство (RU)](docs/features/experience-store/README-ru.md) · [EN](docs/features/experience-store/README.md)
 - ▶️ Демо: `make demo-experience` или `python3 src/demo_experience_store.py` (мгновенно: `make demo-experience-fast`)
 
-**✅ Identity Store** (рабочий пакет 03)
-Честный bootstrap идентичности, eigenstate, трёхслойный self-narrative, снимки, CLI.
+#### В активной разработке
 
-- 📚 [Руководство (RU)](docs/features/identity-store/README-ru.md) · [EN](docs/features/identity-store/README.md)
-- ▶️ Демо: `make demo-identity` или `python3 src/demo_identity.py` (мгновенно: `make demo-identity-fast`)
+**🔧 Session Manager** (рабочий пакет 05) — **высокая готовность · текущий фокус**
+Сессионный runtime в реальном времени: окраска опыта от первого лица, key moments с обязательной эмоциональной меткой, генерация eigenstate, обновление нарратива. Прототип на месте; сейчас — проводка, краевые случаи и отладка перед более широкой аудиторией.
 
-**✅ Reflection Engine** (рабочий пакет 04)
-Micro / daily / deep рефлексия, паттерны, хуки правки нарратива, оценка здоровья по Джаходе, советник по принципам.
+- 📚 [Руководство (RU)](docs/features/session-manager/README-ru.md) · [EN](docs/features/session-manager/README.md)
+- ▶️ Демо: `make demo-session` или `python3 src/demo_session_manager.py` (мгновенно: `make demo-session-fast`)
+
+**🔧 Reflection Engine** (рабочий пакет 04) — **средняя готовность**
+Micro / daily / deep рефлексия, паттерны, хуки правки нарратива, оценка здоровья по Джаходе, советник по принципам. Демо и тесты есть; «внутренняя жизнь» между сессиями для продакшен-агентов пока не опирается на это надёжно.
 
 - 📚 [Руководство (RU)](docs/features/reflection-engine/README-ru.md) · [EN](docs/features/reflection-engine/README.md)
 - ▶️ Демо: `make demo-reflection` или `python3 src/demo_reflection.py` (мгновенно: `make demo-reflection-fast`)
 
-**✅ Session Manager** (рабочий пакет 05)
-Сессионный runtime в реальном времени: окраска опыта от первого лица, key moments с обязательной эмоциональной меткой, генерация eigenstate, обновление нарратива.
+**🔧 Skill Manager** (рабочий пакет 08) — **средняя готовность**
+Слой переносимых навыков (дизайн + бэклог; реализация в процессе). Форма API и хранения может меняться по мере стабилизации сессии и рефлексии.
 
-- 📚 [Руководство (RU)](docs/features/session-manager/README-ru.md) · [EN](docs/features/session-manager/README.md)
-- ▶️ Демо: `make demo-session` или `python3 src/demo_session_manager.py` (мгновенно: `make demo-session-fast`)
+- 📚 Заметки по дизайну: [`docs/archive/2026-05/skill-manager-design.md`](docs/archive/2026-05/skill-manager-design.md)
+
+**🔧 Identity Store** (рабочий пакет 03) — **низкая готовность**
+Честный bootstrap идентичности, eigenstate, трёхслойный self-narrative, снимки, CLI. Полезно для экспериментов; относительно сессионного пути, который сейчас укрепляем, — ещё рано.
+
+- 📚 [Руководство (RU)](docs/features/identity-store/README-ru.md) · [EN](docs/features/identity-store/README.md)
+- ▶️ Демо: `make demo-identity` или `python3 src/demo_identity.py` (мгновенно: `make demo-identity-fast`)
 
 ```bash
 # Быстрый старт (установка + интерактивный CLI фактов)

--- a/docs/content/README.md
+++ b/docs/content/README.md
@@ -5,10 +5,10 @@
 > **Continuous Identity for Your Agents**
 
 [![CI](https://github.com/hleserg/atman/actions/workflows/ci.yml/badge.svg)](https://github.com/hleserg/atman/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/github/hleserg/atman/graph/badge.svg?token=1S9D9U8QZP)](https://codecov.io/github/hleserg/atman)
+[![CodeFactor](https://www.codefactor.io/repository/github/hleserg/atman/badge)](https://www.codefactor.io/repository/github/hleserg/atman)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
-
-**Tests:** 1764 passing, 138 skipped (`pytest tests/` on `main`; see CI workflow above).
 
 [[ru](README-ru.md)] — *Russian version*
 
@@ -60,20 +60,27 @@ Under the hood — seven components: store of lived experiences, reflection engi
 ● Research              ✅ Complete
 ● Design                ✅ Complete
 ● Prototyping           ← We are here
-  ├─ Factual Memory     ✅ Implemented (v0.1.0)
-  ├─ Experience Store   ✅ Implemented (WP02)
-  ├─ Identity Store     ✅ Implemented (WP03)
-  ├─ Reflection Engine  ✅ Implemented (WP04)
-  ├─ Session Manager    ✅ Implemented (WP05)
+  ├─ Factual Memory     ✅ Stable (v0.1.0)
+  ├─ Experience Store   ✅ Stable (WP02)
+  ├─ Session Manager    🔧 High readiness — debugging (current focus)
+  ├─ Reflection Engine  🔧 Medium readiness — in development
+  ├─ Skill Manager      🔧 Medium readiness — in development
+  ├─ Identity Store     🔧 Low readiness — in development
   └─ CI & test coverage ✅ GitHub Actions on `main`/PRs (`make check`, pytest-cov ≥90%)
-○ First implementation
+○ First production slice
 ○ Integration
 ○ Evolution
 ```
 
-### Ready components
+**Honest snapshot (May 2026):** memory foundations (facts + first-hand experience) are usable on their own. **Session**, **reflection**, **identity**, and **skills** already have prototype code, demos, and tests — but the full “continuous identity” loop is **not production-ready** yet. Right now the team is on **Session Manager**: integration and debugging before wider onboarding.
+
+Readiness legend: **high** = core path exists, hardening in progress · **medium** = substantial prototype, gaps in integration · **low** = early slice, needs more work before it carries the product story.
+
+### Component status
 
 - 🌐 **Site — terminal demos:** [atmanai.dev/demo.html](https://atmanai.dev/demo.html) (RU/EN toggle matches the main landing)
+
+#### Stable foundations
 
 **✅ Factual Memory Adapter** ([PR #73](https://github.com/hleserg/atman/pull/73))
 Minimal layer for storing verifiable facts without interpretations.
@@ -93,23 +100,30 @@ First-hand lived experience: `SessionExperience`, `KeyMoment`, salience decay, r
 - 📚 [Guide (EN)](docs/features/experience-store/README.md) · [RU](docs/features/experience-store/README-ru.md)
 - ▶️ Demo: `make demo-experience` or `python3 src/demo_experience_store.py` (`make demo-experience-fast` for instant output)
 
-**✅ Identity Store** (work package 03)
-Honest bootstrap identity, eigenstate, three-layer self-narrative, snapshots, CLI.
+#### In active development
 
-- 📚 [Guide (EN)](docs/features/identity-store/README.md) · [RU](docs/features/identity-store/README-ru.md)
-- ▶️ Demo: `make demo-identity` or `python3 src/demo_identity.py` (`make demo-identity-fast` for instant output)
+**🔧 Session Manager** (work package 05) — **high readiness · current focus**
+Real-time session runtime: first-hand experience coloring, key moments with mandatory emotional marking, eigenstate generation, narrative updates. Prototype is in place; active work is wiring, edge cases, and debugging before a broader audience.
 
-**✅ Reflection Engine** (work package 04)
-Micro / daily / deep reflection, patterns, narrative revision hooks, Jahoda health assessment, principle advisor.
+- 📚 [Guide (EN)](docs/features/session-manager/README.md) · [RU](docs/features/session-manager/README-ru.md)
+- ▶️ Demo: `make demo-session` or `python3 src/demo_session_manager.py` (`make demo-session-fast` for instant output)
+
+**🔧 Reflection Engine** (work package 04) — **medium readiness**
+Micro / daily / deep reflection, patterns, narrative revision hooks, Jahoda health assessment, principle advisor. Runnable demos and tests; not yet a dependable between-session “inner life” for production agents.
 
 - 📚 [Guide (EN)](docs/features/reflection-engine/README.md) · [RU](docs/features/reflection-engine/README-ru.md)
 - ▶️ Demo: `make demo-reflection` or `python3 src/demo_reflection.py` (`make demo-reflection-fast` for instant output)
 
-**✅ Session Manager** (work package 05)
-Real-time session runtime: first-hand experience coloring, key moments with mandatory emotional marking, eigenstate generation, narrative updates.
+**🔧 Skill Manager** (work package 08) — **medium readiness**
+Transferable skills layer (design + backlog; implementation in progress). Expect API and storage shape to move as session and reflection paths stabilize.
 
-- 📚 [Guide (EN)](docs/features/session-manager/README.md) · [RU](docs/features/session-manager/README-ru.md)
-- ▶️ Demo: `make demo-session` or `python3 src/demo_session_manager.py` (`make demo-session-fast` for instant output)
+- 📚 Design notes: [`docs/archive/2026-05/skill-manager-design.md`](docs/archive/2026-05/skill-manager-design.md)
+
+**🔧 Identity Store** (work package 03) — **low readiness**
+Honest bootstrap identity, eigenstate, three-layer self-narrative, snapshots, CLI. Useful for experiments; still early relative to the session-centric path we are hardening now.
+
+- 📚 [Guide (EN)](docs/features/identity-store/README.md) · [RU](docs/features/identity-store/README-ru.md)
+- ▶️ Demo: `make demo-identity` or `python3 src/demo_identity.py` (`make demo-identity-fast` for instant output)
 
 ```bash
 # Quick start (install + interactive factual CLI)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the main README roadmap to reflect prototyping reality before wider onboarding: factual memory and experience store are stable; session, reflection, skills, and identity are still in development with explicit readiness levels (session high / current focus on debugging; reflection and skills medium; identity low).

## Changes

- `README.md` — roadmap tree, honest May 2026 snapshot, split into *Stable foundations* vs *In active development*
- `README-ru.md` — matching Russian copy
- `docs/content/README.md` and `docs/content/README-ru.md` — synced for the static site

## How to verify

- Read the **Roadmap** / **Дорожная карта** sections in both README files
- Optional: `make docs-preview` and open the site README copy

## PLAYBOOK markers

- [x] No generalizable patterns (documentation only)

## System map

**N/A** — documentation-only; no code or architecture changes.

## Tests

**N/A** — no runtime behavior changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51ceec5c-dceb-4acd-8b4c-5d389545e9ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51ceec5c-dceb-4acd-8b4c-5d389545e9ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

