### PR TITLE
feat(observability): P2.x instrumentation — tools, storage, ATMAN_SEND_PROMPTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,8 @@ MANIFEST
 .coverage
 htmlcov/
 .tox/
+coverage.xml
+junit.xml
 
 # Atman
 .atman/

--- a/.sentry-instrumentation-allowlist
+++ b/.sentry-instrumentation-allowlist
@@ -46,14 +46,7 @@ adapters.agent.preflight.start_warmup_background
 adapters.agent.preflight.run_cli_preflight
 adapters.agent.preflight.run_streamlit_preflight
 
-# Agent tools (P2.x — will be instrumented when Anthropic/Cohere adapters land)
-adapters.agent.runner.chat
-adapters.agent.tools.record_key_moment
-adapters.agent.tools.log_experience
-adapters.agent.tools.restart_session
-adapters.agent.tools.wait_session
-adapters.agent.tools.resolve_pending_review
-adapters.agent.tools.request_reflection
+# Agent tools — all instrumented in P2.x (spans or # sentry: skip markers inline)
 
 # Legacy sentry helpers — ARE the instrumentation layer, instrumenting them
 # would be circular
@@ -77,8 +70,4 @@ adapters.reflection.fixture_loader.load_reflection_session_experiences
 adapters.reflection.fixture_loader.load_reflection_identity
 adapters.reflection.fixture_loader.anchor_session_experiences_to_utc_day_window
 
-# Storage helpers (thin wrappers — P2.8 will add parent business-op spans)
-adapters.storage._atomic_write.write_atomically
-adapters.storage.reflection_persistence_helper.persist_micro_reflection
-adapters.storage.reflection_persistence_helper.persist_daily_reflection
-adapters.storage.reflection_persistence_helper.persist_deep_reflection
+# Storage helpers — all instrumented in P2.8/P2.9 (db_span / memory_span inline)

--- a/docs/features/observability/instrumentation-allowlist-rationale.md
+++ b/docs/features/observability/instrumentation-allowlist-rationale.md
@@ -48,18 +48,18 @@ why it is exempt from the Sentry instrumentation requirement.
 
 | Function | Rationale |
 |----------|-----------|
-| `chat` | Will be instrumented in P2.4 (Anthropic adapter + AtmanTurn) |
+| `chat` | Stub pending P2.4 (Anthropic adapter + AtmanTurn); `# sentry: skip` inline. Production telemetry lives in `AtmanRunner.chat()` via `AtmanTurn.pre()/post()`. |
 
 ## adapters/agent/tools.*
 
 | Function | Rationale |
 |----------|-----------|
-| `record_key_moment` | Will be instrumented in P2.x (memory_span) |
-| `log_experience` | Will be instrumented in P2.x (memory_span) |
-| `restart_session` | Thin session lifecycle helper; will be instrumented in P2.x |
-| `wait_session` | Thin session lifecycle helper |
-| `resolve_pending_review` | Will be instrumented in P2.x |
-| `request_reflection` | Will be instrumented in P2.9 (reflection cron) |
+| `record_key_moment` | Instrumented via `memory_span("submit_self_report", "key_moments")` (P2.x ✓) |
+| `log_experience` | Deprecated no-op redirect; `# sentry: skip` inline (P2.x ✓) |
+| `restart_session` | Returns sentinel string only; `# sentry: skip` inline; restart telemetry owned by `AtmanRunner._do_restart` (P2.x ✓) |
+| `wait_session` | Returns sentinel string only; `# sentry: skip` inline (P2.x ✓) |
+| `resolve_pending_review` | Instrumented via `pipeline_span("atman.review.resolve", ...)` (P2.x ✓) |
+| `request_reflection` | Instrumented via `pipeline_span("atman.reflection.request", ...)` (P2.9 ✓) |
 
 ## adapters/observability/sentry.*
 
@@ -101,12 +101,12 @@ The callers (reflection services) own the spans around the full reflection cycle
 
 | Function | Rationale |
 |----------|-----------|
-| `write_atomically` | Low-level file I/O helper; will be covered by parent `db_span` in P2.8 |
+| `write_atomically` | Instrumented via `db_span("filesystem", "write", collection=path.name)` (P2.8 ✓) |
 
 ## adapters/storage/reflection_persistence_helper.*
 
 | Function | Rationale |
 |----------|-----------|
-| `persist_micro_reflection` | Will be instrumented in P2.9 (reflection spans) |
-| `persist_daily_reflection` | Will be instrumented in P2.9 |
-| `persist_deep_reflection` | Will be instrumented in P2.9 |
+| `persist_micro_reflection` | Instrumented via `memory_span("persist", "reflection.micro")` (P2.9 ✓) |
+| `persist_daily_reflection` | Instrumented via `memory_span("persist", "reflection.daily")` (P2.9 ✓) |
+| `persist_deep_reflection` | Instrumented via `memory_span("persist", "reflection.deep")` (P2.9 ✓) |

--- a/src/atman/adapters/agent/runner.py
+++ b/src/atman/adapters/agent/runner.py
@@ -180,7 +180,7 @@ def _auto_record_refusal_if_needed(
 # PLAYBOOK-END
 
 
-def chat(
+def chat(  # sentry: skip — stub pending P2.4; production telemetry in AtmanRunner.chat() via AtmanTurn
     session_manager: SessionManager,
     session_id: UUID,
     *,
@@ -214,6 +214,8 @@ def chat(
         ... except SystemExit:
         ...     print("Session finished gracefully")
     """
+    # sentry: skip — stub pending P2.4 (Anthropic adapter + AtmanTurn wiring);
+    # production telemetry lives in AtmanRunner.chat() via AtmanTurn.pre()/post().
     interrupted = False
     pending_system_exit: SystemExit | None = None
     # Parameter reserved for future chat-loop paths that distinguish normal vs. forced closure.

--- a/src/atman/adapters/agent/tools.py
+++ b/src/atman/adapters/agent/tools.py
@@ -171,7 +171,9 @@ async def log_experience(  # sentry: skip — deprecated no-op redirect; no I/O 
     )
 
 
-def restart_session(ctx: RunContext[AtmanDeps], reason: str = "") -> str:  # sentry: skip — sentinel only; restart telemetry in AtmanRunner._do_restart
+def restart_session(
+    ctx: RunContext[AtmanDeps], reason: str = ""
+) -> str:  # sentry: skip — sentinel only; restart telemetry in AtmanRunner._do_restart
     """
     Request immediate session restart.
 
@@ -197,7 +199,9 @@ def restart_session(ctx: RunContext[AtmanDeps], reason: str = "") -> str:  # sen
     return "__ATMAN_RESTART_REQUESTED__"
 
 
-def wait_session(ctx: RunContext[AtmanDeps], minutes: int) -> str:  # sentry: skip — returns sentinel string only; no I/O
+def wait_session(
+    ctx: RunContext[AtmanDeps], minutes: int
+) -> str:  # sentry: skip — returns sentinel string only; no I/O
     """
     Request session pause for specified minutes.
 

--- a/src/atman/adapters/agent/tools.py
+++ b/src/atman/adapters/agent/tools.py
@@ -171,9 +171,9 @@ async def log_experience(  # sentry: skip — deprecated no-op redirect; no I/O 
     )
 
 
-def restart_session(
+def restart_session(  # sentry: skip — sentinel only; restart telemetry in AtmanRunner._do_restart
     ctx: RunContext[AtmanDeps], reason: str = ""
-) -> str:  # sentry: skip — sentinel only; restart telemetry in AtmanRunner._do_restart
+) -> str:
     """
     Request immediate session restart.
 
@@ -199,9 +199,9 @@ def restart_session(
     return "__ATMAN_RESTART_REQUESTED__"
 
 
-def wait_session(
+def wait_session(  # sentry: skip — returns sentinel string only; no I/O
     ctx: RunContext[AtmanDeps], minutes: int
-) -> str:  # sentry: skip — returns sentinel string only; no I/O
+) -> str:
     """
     Request session pause for specified minutes.
 

--- a/src/atman/adapters/agent/tools.py
+++ b/src/atman/adapters/agent/tools.py
@@ -27,6 +27,7 @@ from atman.core.models.reflection_request import (
     ReflectionRequestLevel,
 )
 from atman.core.reflection_run_keys import agent_driven_run_key
+from atman.observability.spans import memory_span, pipeline_span
 
 # PLAYBOOK-START
 # id: error-returning-tool-callbacks
@@ -143,14 +144,15 @@ async def record_key_moment(
             why_it_matters=why_it_matters,
             tags=[f"depth:{depth}"],
         )
-        await det.submit_self_report(report, session_id=ctx.deps.session_id)
+        with memory_span("submit_self_report", "key_moments"):
+            await det.submit_self_report(report, session_id=ctx.deps.session_id)
         summary = what_happened if len(what_happened) <= 50 else f"{what_happened[:50]}..."
         return f"Key moment recorded via AffectDetector: {summary}"
     except Exception as e:
         return f"Error recording key moment: {e!s}"
 
 
-async def log_experience(
+async def log_experience(  # sentry: skip — deprecated no-op redirect; no I/O performed
     ctx: RunContext[AtmanDeps],
     what_happened: str,
     why_it_matters: str = "",
@@ -169,7 +171,7 @@ async def log_experience(
     )
 
 
-def restart_session(ctx: RunContext[AtmanDeps], reason: str = "") -> str:
+def restart_session(ctx: RunContext[AtmanDeps], reason: str = "") -> str:  # sentry: skip — sentinel only; restart telemetry in AtmanRunner._do_restart
     """
     Request immediate session restart.
 
@@ -187,13 +189,15 @@ def restart_session(ctx: RunContext[AtmanDeps], reason: str = "") -> str:
     The sentinel format uses newline as delimiter when reason is provided
     to ensure unambiguous parsing.
     """
+    # sentry: skip — returns a sentinel string only; no I/O; actual restart telemetry
+    # is captured in AtmanRunner._do_restart which owns the session lifecycle spans.
     _ = ctx  # Unused; reserved for future validation
     if reason:
         return f"__ATMAN_RESTART_REQUESTED__\n{reason}"
     return "__ATMAN_RESTART_REQUESTED__"
 
 
-def wait_session(ctx: RunContext[AtmanDeps], minutes: int) -> str:
+def wait_session(ctx: RunContext[AtmanDeps], minutes: int) -> str:  # sentry: skip — returns sentinel string only; no I/O
     """
     Request session pause for specified minutes.
 
@@ -208,6 +212,7 @@ def wait_session(ctx: RunContext[AtmanDeps], minutes: int) -> str:
     and use to trigger wait/pause logic. The runner is responsible for
     handling the actual wait workflow (E22.5).
     """
+    # sentry: skip — returns a sentinel string only; no I/O performed
     _ = ctx  # Unused; reserved for future validation
 
     if minutes <= 0:
@@ -276,12 +281,13 @@ def resolve_pending_review(
         return f"Error: review_id is not a valid UUID: {review_id!r}"
 
     try:
-        resolved = inbox.resolve(
-            review_uuid,
-            resolution=resolution,
-            note=note_clean,
-            resolved_at=datetime.now(UTC),
-        )
+        with pipeline_span("atman.review.resolve", "resolve pending review"):
+            resolved = inbox.resolve(
+                review_uuid,
+                resolution=resolution,
+                note=note_clean,
+                resolved_at=datetime.now(UTC),
+            )
     except KeyError:
         return f"Error: no pending review with id {review_id}"
     except ValueError as exc:
@@ -344,7 +350,8 @@ def request_reflection(
         requested_at=now,
     )
     try:
-        stored = queue.enqueue(request)
+        with pipeline_span("atman.reflection.request", "enqueue reflection request"):
+            stored = queue.enqueue(request)
     except Exception as exc:
         return f"Error queuing reflection request: {exc!s}"
     if stored.id != request.id:

--- a/src/atman/adapters/storage/_atomic_write.py
+++ b/src/atman/adapters/storage/_atomic_write.py
@@ -10,6 +10,8 @@ import os
 import tempfile
 from pathlib import Path
 
+from atman.observability.spans import db_span
+
 
 def write_atomically(path: Path, content: str) -> None:
     """Write content to path via temp file + fsync + replace.
@@ -17,6 +19,11 @@ def write_atomically(path: Path, content: str) -> None:
     Creates parent dirs if missing. Preserves existing file mode,
     defaults to 0o600. Atomic across crashes via os.replace.
     """
+    with db_span("filesystem", "write", collection=path.name):
+        _write_atomically_impl(path, content)
+
+
+def _write_atomically_impl(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     file_mode = path.stat().st_mode & 0o777 if path.exists() else 0o600
     temp_file = tempfile.NamedTemporaryFile(

--- a/src/atman/adapters/storage/reflection_persistence_helper.py
+++ b/src/atman/adapters/storage/reflection_persistence_helper.py
@@ -16,6 +16,7 @@ from atman.core.models.reflection import (
     ReflectionRecord,
 )
 from atman.core.ports.reflection_store import ReflectionStore
+from atman.observability.spans import memory_span
 
 
 def persist_micro_reflection(
@@ -64,7 +65,8 @@ def persist_micro_reflection(
         record_params["created_at"] = created_at
 
     record = ReflectionRecord(**record_params)
-    return store.add(record)
+    with memory_span("persist", "reflection.micro"):
+        return store.add(record)
 
 
 def persist_daily_reflection(
@@ -110,7 +112,8 @@ def persist_daily_reflection(
         model_provider=model_provider,
         model_name=model_name,
     )
-    return store.add(record)
+    with memory_span("persist", "reflection.daily"):
+        return store.add(record)
 
 
 def persist_deep_reflection(
@@ -172,4 +175,5 @@ def persist_deep_reflection(
         model_name=model_name,
         metadata=metadata,
     )
-    return store.add(record)
+    with memory_span("persist", "reflection.deep"):
+        return store.add(record)

--- a/src/atman/observability/scrubbing.py
+++ b/src/atman/observability/scrubbing.py
@@ -2,10 +2,14 @@
 
 Extends sentry-sdk's DEFAULT_DENYLIST with Atman-specific keys that must
 never reach Sentry SaaS: memory contents, reflections, embeddings, prompts.
+
+Set ATMAN_SEND_PROMPTS=1 together with debug or verbose level to allow raw
+LLM payloads through to Sentry for local debugging. Never use in production.
 """
 
 from __future__ import annotations
 
+import os
 import traceback
 from typing import Any
 
@@ -36,16 +40,26 @@ ATMAN_EXTRA_KEYS: list[str] = [
     "authorization",
 ]
 
+# LLM I/O keys removed from the denylist when ATMAN_SEND_PROMPTS=1
+_LLM_IO_KEYS: frozenset[str] = frozenset(
+    {"embedding_input", "rerank_documents", "prompt", "prompt_text", "completion", "response_text"}
+)
 
-def make_event_scrubber(_level: str) -> Any:
+
+def make_event_scrubber(level: str) -> Any:
     """Return an EventScrubber configured with ATMAN_DENYLIST.
 
-    In verbose mode we still scrub — developer must opt-in to raw payloads
-    via ATMAN_SEND_PROMPTS=1 at the SDK level if needed.
+    When ATMAN_SEND_PROMPTS=1 and level is debug or verbose, LLM I/O keys
+    are removed from the denylist so raw payloads flow through to Sentry.
+    Only use in fully isolated dev environments — never in production.
     """
     from sentry_sdk.scrubber import DEFAULT_DENYLIST, EventScrubber  # lazy import
 
-    denylist: list[str] = list(DEFAULT_DENYLIST) + ATMAN_EXTRA_KEYS
+    send_prompts = os.getenv("ATMAN_SEND_PROMPTS", "").strip() == "1"
+    allow_prompts = send_prompts and level in ("debug", "verbose")
+
+    extra_keys = [k for k in ATMAN_EXTRA_KEYS if not (allow_prompts and k in _LLM_IO_KEYS)]
+    denylist: list[str] = list(DEFAULT_DENYLIST) + extra_keys
     return EventScrubber(denylist=denylist, recursive=True)
 
 

--- a/tests/observability/test_scrubbing.py
+++ b/tests/observability/test_scrubbing.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from atman.observability.scrubbing import (
     _HEALTH_ROUTES,
+    _LLM_IO_KEYS,
     ATMAN_EXTRA_KEYS,
     _make_before_send,
     _make_before_send_transaction,
@@ -94,3 +97,33 @@ def test_health_routes_set():
     assert "/metrics" in _HEALTH_ROUTES
     assert "/livez" in _HEALTH_ROUTES
     assert "/readyz" in _HEALTH_ROUTES
+
+
+def test_send_prompts_off_by_default(monkeypatch):
+    monkeypatch.delenv("ATMAN_SEND_PROMPTS", raising=False)
+    scrubber = make_event_scrubber("debug")
+    assert "prompt" in scrubber.denylist
+    assert "completion" in scrubber.denylist
+
+
+@pytest.mark.parametrize("level", ["debug", "verbose"])
+def test_send_prompts_enabled_removes_llm_keys(monkeypatch, level):
+    monkeypatch.setenv("ATMAN_SEND_PROMPTS", "1")
+    scrubber = make_event_scrubber(level)
+    for key in _LLM_IO_KEYS:
+        assert key not in scrubber.denylist, f"Expected {key!r} absent when ATMAN_SEND_PROMPTS=1"
+
+
+def test_send_prompts_ignored_at_minimal_level(monkeypatch):
+    monkeypatch.setenv("ATMAN_SEND_PROMPTS", "1")
+    scrubber = make_event_scrubber("minimal")
+    assert "prompt" in scrubber.denylist
+    assert "completion" in scrubber.denylist
+
+
+def test_send_prompts_non_llm_keys_always_scrubbed(monkeypatch):
+    monkeypatch.setenv("ATMAN_SEND_PROMPTS", "1")
+    scrubber = make_event_scrubber("verbose")
+    assert "memory_content" in scrubber.denylist
+    assert "reflection_text" in scrubber.denylist
+    assert "identity_payload" in scrubber.denylist


### PR DESCRIPTION
## Summary

Completes the remaining open P2.x tasks from the **Sentry Observability** Linear project. All closed issues were verified as implemented in `main`; only the P2.x items below were genuinely open.

### P2.x — Agent tools instrumented

| Function | Span / marker |
|----------|---------------|
| `record_key_moment` | `memory_span("submit_self_report", "key_moments")` around `det.submit_self_report()` |
| `resolve_pending_review` | `pipeline_span("atman.review.resolve")` around `inbox.resolve()` |
| `request_reflection` | `pipeline_span("atman.reflection.request")` around `queue.enqueue()` |
| `log_experience` | `# sentry: skip` — deprecated no-op |
| `restart_session` | `# sentry: skip` — sentinel string only; restart telemetry in `AtmanRunner._do_restart` |
| `wait_session` | `# sentry: skip` — sentinel string only |
| `runner.chat` (stub) | `# sentry: skip` pending P2.4; production telemetry in `AtmanRunner.chat()` via `AtmanTurn` |

### P2.8 — `write_atomically`

`db_span("filesystem", "write", collection=path.name)` added; implementation extracted to `_write_atomically_impl`.

### P2.9 — Reflection persistence helpers

| Function | Span |
|----------|------|
| `persist_micro_reflection` | `memory_span("persist", "reflection.micro")` |
| `persist_daily_reflection` | `memory_span("persist", "reflection.daily")` |
| `persist_deep_reflection` | `memory_span("persist", "reflection.deep")` |

### ATMAN_SEND_PROMPTS (doc bug → implemented)

`ATMAN_SEND_PROMPTS=1` was documented in `levels.md` but not implemented in code. Now:
- When `ATMAN_SEND_PROMPTS=1` + level `debug`/`verbose`, LLM I/O keys (`prompt`, `completion`, `embedding_input`, `rerank_documents`, etc.) are removed from `EventScrubber` denylist so raw payloads flow through to Sentry for local debugging.
- Ignored at `minimal` level (production default) — safe by default.
- 5 new tests cover all combinations.

### Allowlist cleanup

Removed 11 functions from `.sentry-instrumentation-allowlist` (now use inline spans or `# sentry: skip`). Updated `instrumentation-allowlist-rationale.md` with final status.

## Test plan

- [x] `python tools/check_instrumentation.py` — 70 files, 0 violations
- [x] `pytest tests/observability/ tests/test_sentry_metrics.py tests/test_sentry_slog_hook.py` — 113 passed (108 + 5 new ATMAN_SEND_PROMPTS tests)
- [x] `pytest tests/ -q --ignore=tests/integration --ignore=tests/atman_eval --ignore=tests/e2e` — 2187 passed, 0 failed
- [x] `ruff check` + `pyright` — no errors

https://claude.ai/code/session_01SsXqEThrDzmpVU4at7H3LU

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsXqEThrDzmpVU4at7H3LU)_