### PR TITLE
chore(site): sync content to docs/content/ [skip ci]

### DIFF
--- a/README-ru.md
+++ b/README-ru.md
@@ -161,3 +161,15 @@ pytest tests/ -v       # все тесты (или: uv run pytest tests/ -v)
 
 - Email: [hello@atmanai.dev](mailto:hello@atmanai.dev)
 - Telegram: [@skhlebnikov](https://t.me/skhlebnikov)
+
+---
+
+## Благодарности
+
+<a href="https://sentry.io" target="_blank">
+  <img src="/docs/pic/sentry-wordmark-light-400x119.png" 
+       alt="Sentry" width="150" />
+</a>
+
+Мониторинг ошибок и наблюдаемость для Atman работает на [Sentry](https://sentry.io) —  
+спасибо за поддержку проектов с открытым исходным кодом. 🙏

--- a/docs/content/README-ru.md
+++ b/docs/content/README-ru.md
@@ -5,6 +5,7 @@
 > **Непрерывная личность для ваших агентов**
 
 [![CI](https://github.com/hleserg/atman/actions/workflows/ci.yml/badge.svg)](https://github.com/hleserg/atman/actions/workflows/ci.yml)
+[![Sentry](https://img.shields.io/badge/monitored%20by-Sentry-362D59?logo=sentry&logoColor=white)](https://sentry.io)
 [![codecov](https://codecov.io/github/hleserg/atman/graph/badge.svg?token=1S9D9U8QZP)](https://codecov.io/github/hleserg/atman)
 [![CodeFactor](https://www.codefactor.io/repository/github/hleserg/atman/badge)](https://www.codefactor.io/repository/github/hleserg/atman)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
@@ -160,3 +161,15 @@ pytest tests/ -v       # все тесты (или: uv run pytest tests/ -v)
 
 - Email: [hello@atmanai.dev](mailto:hello@atmanai.dev)
 - Telegram: [@skhlebnikov](https://t.me/skhlebnikov)
+
+---
+
+## Благодарности
+
+<a href="https://sentry.io" target="_blank">
+  <img src="/docs/pic/sentry-wordmark-light-400x119.png" 
+       alt="Sentry" width="150" />
+</a>
+
+Мониторинг ошибок и наблюдаемость для Atman работает на [Sentry](https://sentry.io) —  
+спасибо за поддержку проектов с открытым исходным кодом. 🙏

--- a/docs/content/README.md
+++ b/docs/content/README.md
@@ -5,6 +5,7 @@
 > **Continuous Identity for Your Agents**
 
 [![CI](https://github.com/hleserg/atman/actions/workflows/ci.yml/badge.svg)](https://github.com/hleserg/atman/actions/workflows/ci.yml)
+[![Sentry](https://img.shields.io/badge/monitored%20by-Sentry-362D59?logo=sentry&logoColor=white)](https://sentry.io)
 [![codecov](https://codecov.io/github/hleserg/atman/graph/badge.svg?token=1S9D9U8QZP)](https://codecov.io/github/hleserg/atman)
 [![CodeFactor](https://www.codefactor.io/repository/github/hleserg/atman/badge)](https://www.codefactor.io/repository/github/hleserg/atman)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
@@ -158,3 +159,15 @@ I welcome any communication, feedback, or exchange of ideas:
 
 - Email: [hello@atmanai.dev](mailto:hello@atmanai.dev)
 - Telegram: [@skhlebnikov](https://t.me/skhlebnikov)
+
+---
+
+## Acknowledgements
+
+<a href="https://sentry.io" target="_blank">
+  <img src="/docs/pic/sentry-wordmark-light-400x119.png" 
+       alt="Sentry" width="150" />
+</a>
+
+Error monitoring and observability for Atman is powered by [Sentry](https://sentry.io) —  
+thank you for supporting open-source projects. 🙏


### PR DESCRIPTION
## Summary

- Synced `README.md` and `README-ru.md` to `docs/content/` (the other 6 file pairs were already identical)
- Fixed translation quality issue: `README-ru.md` was missing the `## Благодарности` (Acknowledgements) section — source had 7 `##` headers, RU translation had only 6

## Changes

| File | Change |
|------|--------|
| `README-ru.md` | Added missing `## Благодарности` section (translation of Acknowledgements) |
| `docs/content/README.md` | Synced from source (Sentry badge + Acknowledgements section now present) |
| `docs/content/README-ru.md` | Synced from source (Sentry badge + Благодарности section now present) |

## Test plan

- [x] All 8 source→content file pairs verified identical after sync (`diff` exits 0)
- [x] `README-ru.md` now has 7 `##` headers matching `README.md`

https://claude.ai/code/session_01GSmAJLor8j9ENgBVbD7KTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSmAJLor8j9ENgBVbD7KTA)_