### PR TITLE
chore(site): sync content to docs/content/

### DIFF
--- a/docs/architecture/SYSTEM_MAP-ru.md
+++ b/docs/architecture/SYSTEM_MAP-ru.md
@@ -31,7 +31,7 @@
 | `core/models/entity.py` | Доменные модели Entity Registry: типы сущностей, псевдонимы, отношения, позиции и таблицы связей для фактов и ключевых моментов | `Entity`, `EntityAlias`, `EntityRelation`, `EntityStance`, `EntityType`, `FactEntityLink`, `KeyMomentEntityLink`, `ResolutionMethod` |
 | `core/models/validation.py` | Модели наблюдаемости: находки валидации (качество данных) и события расхождения (анализ разрыва thinking↔сообщение) | `ValidationFinding`, `FindingSeverity`, `FindingType`, `DivergenceEvent`, `DivergenceSeverity`, `DivergenceType` |
 | `core/models/maintenance.py` | Модели очереди технического обслуживания для фоновых/cron задач (salience decay, memory guardian) | `MaintenanceJob`, `JobName`, `JobStatus` |
-| `core/models/reflection.py` | Процесс рефлексии, паттерны, оценка здоровья (критерии Йоды), структурированные ответы модели (MODEL-01 / #146), **персистентность рефлексий в PostgreSQL** (E27) | `ReflectionLevel`, `PatternCandidate`, `PatternStatus`, `PatternType`, `ReflectionEvent`, `HealthAssessment`, `JahodaCriterion`, `CriterionAssessment`, `ReframingNoteOutput`, `PatternDetectionOutput`, `NarrativeUpdateOutput`, `HealthCriterionOutput`, **`ReflectionRecord`** |
+| `core/models/reflection.py` | Процесс рефлексии, паттерны, оценка здоровья (критерии Яходы), структурированные ответы модели (MODEL-01 / #146), **персистентность рефлексий в PostgreSQL** (E27) | `ReflectionLevel`, `PatternCandidate`, `PatternStatus`, `PatternType`, `ReflectionEvent`, `HealthAssessment`, `JahodaCriterion`, `CriterionAssessment`, `ReframingNoteOutput`, `PatternDetectionOutput`, `NarrativeUpdateOutput`, `HealthCriterionOutput`, **`ReflectionRecord`** |
 | `core/models/governance.py` | Решения governance для мутаций ядра нарратива | `GovernanceDecision`, `GovernanceMode` |
 | `core/models/self_applied_change.py` (R11.5) | Аудит-запись об изменении identity/narrative, применённом самой рефлексией (rationale, опорные moment id, snapshot до) | `SelfAppliedChange`, `SelfChangeSource`, `SelfChangeTargetKind`, `SelfChangeActor` |
 | `core/models/pending_human_review.py` (R11.7) | Очередь предложений, в которых рефлексия не уверена и передаёт человеку | `PendingReview`, `PendingReviewDraft`, `PendingReviewKind`, `Priority`, `Resolution` |
@@ -453,7 +453,7 @@ PrincipleRevisionAdvisor — пересмотр принципов
 ### E. Deep reflection + здоровье
 
 1. `DeepReflectionService.reflect_deep(...)`: опыт + паттерны + identity.
-2. Считаются критерии Йоды (autonomy, competence, integration, actualization, aspiration, purpose).
+2. Считаются критерии Яходы (autonomy, competence, integration, actualization, aspiration, purpose).
 3. `ReflectionModel` предлагает правки нарратива (core/recent).
 4. Создаётся `IdentitySnapshot` (идемпотентно по `reflection_run_key`).
 5. Обновляются identity + предложения по нарративу + `HealthAssessment`.

--- a/docs/content/README-ru.md
+++ b/docs/content/README-ru.md
@@ -5,6 +5,7 @@
 > **Непрерывная личность для ваших агентов**
 
 [![CI](https://github.com/hleserg/atman/actions/workflows/ci.yml/badge.svg)](https://github.com/hleserg/atman/actions/workflows/ci.yml)
+[![Sentry](https://img.shields.io/badge/monitored%20by-Sentry-362D59?logo=sentry&logoColor=white)](https://sentry.io)
 [![codecov](https://codecov.io/github/hleserg/atman/graph/badge.svg?token=1S9D9U8QZP)](https://codecov.io/github/hleserg/atman)
 [![CodeFactor](https://www.codefactor.io/repository/github/hleserg/atman/badge)](https://www.codefactor.io/repository/github/hleserg/atman)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)

--- a/docs/content/README.md
+++ b/docs/content/README.md
@@ -5,6 +5,7 @@
 > **Continuous Identity for Your Agents**
 
 [![CI](https://github.com/hleserg/atman/actions/workflows/ci.yml/badge.svg)](https://github.com/hleserg/atman/actions/workflows/ci.yml)
+[![Sentry](https://img.shields.io/badge/monitored%20by-Sentry-362D59?logo=sentry&logoColor=white)](https://sentry.io)
 [![codecov](https://codecov.io/github/hleserg/atman/graph/badge.svg?token=1S9D9U8QZP)](https://codecov.io/github/hleserg/atman)
 [![CodeFactor](https://www.codefactor.io/repository/github/hleserg/atman/badge)](https://www.codefactor.io/repository/github/hleserg/atman)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
@@ -158,3 +159,15 @@ I welcome any communication, feedback, or exchange of ideas:
 
 - Email: [hello@atmanai.dev](mailto:hello@atmanai.dev)
 - Telegram: [@skhlebnikov](https://t.me/skhlebnikov)
+
+---
+
+## Acknowledgements
+
+<a href="https://sentry.io" target="_blank">
+  <img src="/docs/pic/sentry-wordmark-light-400x119.png" 
+       alt="Sentry" width="150" />
+</a>
+
+Error monitoring and observability for Atman is powered by [Sentry](https://sentry.io) —  
+thank you for supporting open-source projects. 🙏

--- a/docs/content/SYSTEM_MAP-ru.md
+++ b/docs/content/SYSTEM_MAP-ru.md
@@ -31,7 +31,7 @@
 | `core/models/entity.py` | Доменные модели Entity Registry: типы сущностей, псевдонимы, отношения, позиции и таблицы связей для фактов и ключевых моментов | `Entity`, `EntityAlias`, `EntityRelation`, `EntityStance`, `EntityType`, `FactEntityLink`, `KeyMomentEntityLink`, `ResolutionMethod` |
 | `core/models/validation.py` | Модели наблюдаемости: находки валидации (качество данных) и события расхождения (анализ разрыва thinking↔сообщение) | `ValidationFinding`, `FindingSeverity`, `FindingType`, `DivergenceEvent`, `DivergenceSeverity`, `DivergenceType` |
 | `core/models/maintenance.py` | Модели очереди технического обслуживания для фоновых/cron задач (salience decay, memory guardian) | `MaintenanceJob`, `JobName`, `JobStatus` |
-| `core/models/reflection.py` | Процесс рефлексии, паттерны, оценка здоровья (критерии Йоды), структурированные ответы модели (MODEL-01 / #146), **персистентность рефлексий в PostgreSQL** (E27) | `ReflectionLevel`, `PatternCandidate`, `PatternStatus`, `PatternType`, `ReflectionEvent`, `HealthAssessment`, `JahodaCriterion`, `CriterionAssessment`, `ReframingNoteOutput`, `PatternDetectionOutput`, `NarrativeUpdateOutput`, `HealthCriterionOutput`, **`ReflectionRecord`** |
+| `core/models/reflection.py` | Процесс рефлексии, паттерны, оценка здоровья (критерии Яходы), структурированные ответы модели (MODEL-01 / #146), **персистентность рефлексий в PostgreSQL** (E27) | `ReflectionLevel`, `PatternCandidate`, `PatternStatus`, `PatternType`, `ReflectionEvent`, `HealthAssessment`, `JahodaCriterion`, `CriterionAssessment`, `ReframingNoteOutput`, `PatternDetectionOutput`, `NarrativeUpdateOutput`, `HealthCriterionOutput`, **`ReflectionRecord`** |
 | `core/models/governance.py` | Решения governance для мутаций ядра нарратива | `GovernanceDecision`, `GovernanceMode` |
 | `core/models/self_applied_change.py` (R11.5) | Аудит-запись об изменении identity/narrative, применённом самой рефлексией (rationale, опорные moment id, snapshot до) | `SelfAppliedChange`, `SelfChangeSource`, `SelfChangeTargetKind`, `SelfChangeActor` |
 | `core/models/pending_human_review.py` (R11.7) | Очередь предложений, в которых рефлексия не уверена и передаёт человеку | `PendingReview`, `PendingReviewDraft`, `PendingReviewKind`, `Priority`, `Resolution` |
@@ -453,7 +453,7 @@ PrincipleRevisionAdvisor — пересмотр принципов
 ### E. Deep reflection + здоровье
 
 1. `DeepReflectionService.reflect_deep(...)`: опыт + паттерны + identity.
-2. Считаются критерии Йоды (autonomy, competence, integration, actualization, aspiration, purpose).
+2. Считаются критерии Яходы (autonomy, competence, integration, actualization, aspiration, purpose).
 3. `ReflectionModel` предлагает правки нарратива (core/recent).
 4. Создаётся `IdentitySnapshot` (идемпотентно по `reflection_run_key`).
 5. Обновляются identity + предложения по нарративу + `HealthAssessment`.


### PR DESCRIPTION
## Summary

Weekly sync of source files to `docs/content/` (site content mirror).

- **README.md** → `docs/content/README.md`: add Sentry badge and Acknowledgements section (were missing from the content copy)
- **README-ru.md** → `docs/content/README-ru.md`: add Sentry badge (was missing from the content copy)
- **SYSTEM_MAP-ru.md** (source + content copy): fix translation error — "критерии Йоды" (of Yoda 🤦) → "критерии Яходы" (Jahoda, the psychologist); occurs in 2 places

MANIFEST.md, MANIFEST-ru.md, SYSTEM.md, SYSTEM-ru.md, SYSTEM_MAP.md — no changes needed (already in sync).

## Test plan

- [ ] Verify `diff README.md docs/content/README.md` is empty
- [ ] Verify `diff README-ru.md docs/content/README-ru.md` is empty
- [ ] Verify `diff docs/architecture/SYSTEM_MAP-ru.md docs/content/SYSTEM_MAP-ru.md` is empty
- [ ] Confirm "Яходы" (Jahoda) appears instead of "Йоды" in SYSTEM_MAP-ru.md

https://claude.ai/code/session_016rXUEZPXUZ8XAoNpxnoks7

---
_Generated by [Claude Code](https://claude.ai/code/session_016rXUEZPXUZ8XAoNpxnoks7)_